### PR TITLE
Name the OSC address constant on both sides of the protocol

### DIFF
--- a/Firmware/FlowerBeds_Follow_ServoController/FlowerBeds_Follow_ServoController.ino
+++ b/Firmware/FlowerBeds_Follow_ServoController/FlowerBeds_Follow_ServoController.ino
@@ -21,6 +21,11 @@ const int32_t baud[MAX_BAUD] = {57600, 115200, 1000000, 2000000, 3000000};
 
 bool activeServos[DXL_BROADCAST_ID];
 
+// OSC address used to receive flower rotation commands.
+// Must match FlowerRotationOSCAddress in the Unreal project
+// (Source/FlowerBeds/FlowerController.h).
+static const char* OSC_FLOWER_ROTATION = "/cg/ff/rot";
+
 // --- Network config ---
 byte mac[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0x15, 0x00 };
 IPAddress ip(192, 168, 1, 50);     // set for your LAN
@@ -48,7 +53,7 @@ void loop() {
   msg.fill(buf, len);
 
   if (!msg.hasError()) {
-    msg.route("/cg/ff/rot", onFlowerRot);
+    msg.route(OSC_FLOWER_ROTATION, onFlowerRot);
   } 
   else {
     // Optional: print parse errors

--- a/FlowerBeds/Source/FlowerBeds/FlowerController.cpp
+++ b/FlowerBeds/Source/FlowerBeds/FlowerController.cpp
@@ -14,7 +14,7 @@ void UFlowerController::Init(const FFlowerControllerConfig& Config)
 
 void UFlowerController::SendFlowerRotation(const uint8 MotorId, float Rotation) const
 {
-	const FOSCAddress FlowerRotationAddress("/cg/ff/rot");
+	const FOSCAddress FlowerRotationAddress(FlowerRotationOSCAddress);
 	UE::OSC::FOSCData MotorIdData(MotorId);
 	UE::OSC::FOSCData RotationData(Rotation);
 	FOSCMessage Message(FlowerRotationAddress, { MotorIdData, RotationData });

--- a/FlowerBeds/Source/FlowerBeds/FlowerController.h
+++ b/FlowerBeds/Source/FlowerBeds/FlowerController.h
@@ -25,6 +25,11 @@ struct FFlowerControllerConfig
 	int32 Port = 0;
 };
 
+// OSC address used to command a flower rotation.
+// Must match OSC_FLOWER_ROTATION in the Arduino firmware
+// (Firmware/FlowerBeds_Follow_ServoController/FlowerBeds_Follow_ServoController.ino).
+inline constexpr const TCHAR* FlowerRotationOSCAddress = TEXT("/cg/ff/rot");
+
 UCLASS(BlueprintType)
 class UFlowerController : public UObject
 {


### PR DESCRIPTION
## Summary

- `"/cg/ff/rot"` was a magic string literal in both `FlowerController.cpp` and the Arduino firmware, with no indication the two were coupled
- `FlowerController.h` now defines `FlowerRotationOSCAddress` with a comment pointing at the firmware file
- The Arduino firmware now defines `OSC_FLOWER_ROTATION` with a comment pointing at `FlowerController.h`
- The literal appears exactly once in each codebase — only in its named constant

No behaviour change.

## Test plan

- Build the UE project and confirm it compiles cleanly
- Flash the firmware and confirm motors still respond to rotation commands from the UE app

https://claude.ai/code/session_01Y6wiijdkMwmF3uMgtRzckj