### PR TITLE
Stub in ATouchScreen for depth-camera touch detection on a grid

### DIFF
--- a/FlowerBeds/Source/FlowerBeds/TouchScreen.cpp
+++ b/FlowerBeds/Source/FlowerBeds/TouchScreen.cpp
@@ -1,0 +1,146 @@
+#include "TouchScreen.h"
+
+#include "FlowerBeds/FlowerBeds.h"
+#include "FlowerBeds/TouchScreenSettings.h"
+#include "OrbbecSensor/Device/OrbbecCameraController.h"
+
+ATouchScreen::ATouchScreen()
+{
+	CameraController = CreateDefaultSubobject<UOrbbecCameraController>("CameraController");
+}
+
+void ATouchScreen::BeginPlay()
+{
+	Super::BeginPlay();
+
+	const UTouchScreenSettings* Settings = GetDefault<UTouchScreenSettings>();
+	if (!Settings)
+	{
+		UE_LOG(LogFlowerBeds, Error, TEXT("ATouchScreen: failed to retrieve touch screen settings."));
+		return;
+	}
+
+	const FTouchScreenConfig* Config = Settings->TouchScreens.FindByPredicate(
+		[Name = ScreenName](const FTouchScreenConfig& C)
+		{
+			return C.Name == Name;
+		});
+
+	if (!Config)
+	{
+		UE_LOG(LogFlowerBeds, Warning,
+			TEXT("ATouchScreen: no config found for screen '%s'. Check UTouchScreenSettings."),
+			*ScreenName.ToString());
+		return;
+	}
+
+	// Actor transform tracks the camera position so depth unprojection can use GetActorTransform().
+	SetActorLocation(Config->CameraPosCm);
+	SetActorRotation(Config->CameraRotation);
+
+	// Store the screen plane as a separate transform.
+	ScreenTransform = FTransform(Config->ScreenRotation, Config->ScreenPosCm);
+	ScreenWidthCm = Config->WidthCm;
+	ScreenHeightCm = Config->HeightCm;
+	TouchThresholdCm = Config->TouchThresholdCm;
+
+	CameraController->CameraConfig = Config->CameraConfig;
+
+	check(CameraController);
+	OnFramesReceivedDelegateHandle =
+		CameraController->OnFramesReceivedNative.AddUObject(this, &ATouchScreen::OnFramesReceived);
+	CameraController->StartCamera();
+}
+
+void ATouchScreen::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+	if (CameraController)
+	{
+		CameraController->OnFramesReceivedNative.Remove(OnFramesReceivedDelegateHandle);
+	}
+
+	Super::EndPlay(EndPlayReason);
+}
+
+void ATouchScreen::SetGrid(int32 Rows, int32 Cols)
+{
+	GridRows = FMath::Max(1, Rows);
+	GridCols = FMath::Max(1, Cols);
+
+	// Fire release events for any currently-touched cells before clearing state.
+	for (const int32 CellIndex : TouchedCellIndices)
+	{
+		FScreenGridCell Cell;
+		Cell.Row = CellIndex / GridCols;
+		Cell.Col = CellIndex % GridCols;
+		OnCellReleased.Broadcast(Cell);
+	}
+
+	TouchedCellIndices.Empty();
+}
+
+void ATouchScreen::OnFramesReceived(
+	const FOrbbecFrame& /* ColorFrame */,
+	const FOrbbecFrame& DepthFrame,
+	const FOrbbecFrame& /* IRFrame */)
+{
+	TArray<FVector2D> NormalisedTouches;
+	DetectTouches(DepthFrame, NormalisedTouches);
+	UpdateTouchedCells(NormalisedTouches);
+}
+
+void ATouchScreen::DetectTouches(const FOrbbecFrame& /* DepthFrame */, TArray<FVector2D>& OutNormalisedTouches) const
+{
+	// TODO: Implement touch detection from the depth frame.
+	// See the detailed approach documented in TouchScreen.h.
+	OutNormalisedTouches.Reset();
+}
+
+bool ATouchScreen::NormalisedPosToCell(const FVector2D& NormPos, FScreenGridCell& OutCell) const
+{
+	if (NormPos.X < 0.f || NormPos.X > 1.f || NormPos.Y < 0.f || NormPos.Y > 1.f)
+	{
+		return false;
+	}
+
+	// Clamp to the last cell index to handle the exact 1.0 edge.
+	OutCell.Row = FMath::Min(static_cast<int32>(NormPos.Y * GridRows), GridRows - 1);
+	OutCell.Col = FMath::Min(static_cast<int32>(NormPos.X * GridCols), GridCols - 1);
+	return true;
+}
+
+void ATouchScreen::UpdateTouchedCells(const TArray<FVector2D>& NormalisedTouches)
+{
+	TSet<int32> NewTouchedIndices;
+
+	for (const FVector2D& NormPos : NormalisedTouches)
+	{
+		FScreenGridCell Cell;
+		if (!NormalisedPosToCell(NormPos, Cell))
+		{
+			continue;
+		}
+
+		const int32 CellIndex = Cell.Row * GridCols + Cell.Col;
+		NewTouchedIndices.Add(CellIndex);
+
+		if (!TouchedCellIndices.Contains(CellIndex))
+		{
+			OnCellTouched.Broadcast(Cell, NormPos);
+		}
+	}
+
+	// Fire release events for cells that were touched last frame but not this one.
+	for (const int32 CellIndex : TouchedCellIndices)
+	{
+		if (!NewTouchedIndices.Contains(CellIndex))
+		{
+			FScreenGridCell Cell;
+			Cell.Row = CellIndex / GridCols;
+			Cell.Col = CellIndex % GridCols;
+			OnCellReleased.Broadcast(Cell);
+		}
+	}
+
+	TouchedCellIndices = MoveTemp(NewTouchedIndices);
+}

--- a/FlowerBeds/Source/FlowerBeds/TouchScreen.h
+++ b/FlowerBeds/Source/FlowerBeds/TouchScreen.h
@@ -1,0 +1,158 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+#include "TouchScreen.generated.h"
+
+struct FOrbbecFrame;
+class UOrbbecCameraController;
+
+/**
+ * Identifies a single cell in the touch grid by its zero-based row and column.
+ * Row 0 is the top of the screen; Col 0 is the left.
+ */
+USTRUCT(BlueprintType)
+struct FScreenGridCell
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Touch Screen")
+	int32 Row = 0;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Touch Screen")
+	int32 Col = 0;
+
+	bool operator==(const FScreenGridCell& Other) const
+	{
+		return Row == Other.Row && Col == Other.Col;
+	}
+};
+
+/**
+ * Fired when a grid cell transitions from untouched to touched.
+ * NormalisedPos is the [0,1]x[0,1] position within the screen (origin top-left).
+ */
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(
+	FOnCellTouched,
+	FScreenGridCell, Cell,
+	FVector2D, NormalisedPos);
+
+/**
+ * Fired when a previously-touched grid cell is no longer touched.
+ */
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
+	FOnCellReleased,
+	FScreenGridCell, Cell);
+
+/**
+ * Actor representing a depth-camera-backed touch screen.
+ *
+ * The actor transform tracks the Orbbec camera that observes the screen.
+ * The physical screen surface is a separate plane defined by ScreenTransform,
+ * ScreenWidthCm, and ScreenHeightCm (populated from UTouchScreenSettings at BeginPlay).
+ *
+ * The screen surface is divided into a dynamic grid whose dimensions are set by
+ * calling SetGrid() before each CAPTCHA challenge. Touch events are broadcast via
+ * OnCellTouched and OnCellReleased.
+ *
+ * Place a BP_TouchScreen (Blueprint subclass) in the level and set ScreenName to
+ * match the corresponding entry in Project Settings → Touch Screen Settings.
+ */
+UCLASS(ClassGroup = (FlowerBeds))
+class ATouchScreen : public AActor
+{
+	GENERATED_BODY()
+
+public:
+	/**
+	 * Matches this actor against FTouchScreenConfig::Name in UTouchScreenSettings.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Touch Screen")
+	FName ScreenName = NAME_None;
+
+	/**
+	 * Reconfigure the grid dimensions. Clears any currently-touched cells and fires
+	 * release events for them. Call this before presenting each new CAPTCHA challenge.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Touch Screen")
+	void SetGrid(int32 Rows, int32 Cols);
+
+	UFUNCTION(BlueprintPure, Category = "Touch Screen")
+	int32 GetGridRows() const { return GridRows; }
+
+	UFUNCTION(BlueprintPure, Category = "Touch Screen")
+	int32 GetGridCols() const { return GridCols; }
+
+	/** Fired when a cell transitions from untouched → touched. */
+	UPROPERTY(BlueprintAssignable, Category = "Touch Screen")
+	FOnCellTouched OnCellTouched;
+
+	/** Fired when a cell transitions from touched → untouched. */
+	UPROPERTY(BlueprintAssignable, Category = "Touch Screen")
+	FOnCellReleased OnCellReleased;
+
+	ATouchScreen();
+	virtual void BeginPlay() override;
+	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+private:
+	int32 GridRows = 3;
+	int32 GridCols = 3;
+
+	// Screen plane geometry, populated from config at BeginPlay.
+	FTransform ScreenTransform;
+	float ScreenWidthCm = 0.f;
+	float ScreenHeightCm = 0.f;
+	float TouchThresholdCm = 5.f;
+
+	// Set of currently-touched cells, encoded as (Row * GridCols + Col).
+	TSet<int32> TouchedCellIndices;
+
+	UPROPERTY(Transient)
+	TObjectPtr<UOrbbecCameraController> CameraController;
+
+	FDelegateHandle OnFramesReceivedDelegateHandle;
+
+	void OnFramesReceived(
+		const FOrbbecFrame& ColorFrame,
+		const FOrbbecFrame& DepthFrame,
+		const FOrbbecFrame& IRFrame);
+
+	/**
+	 * Projects depth-frame pixels onto the screen plane and returns the normalised
+	 * [0,1]x[0,1] screen-space positions of detected touch candidates.
+	 *
+	 * TODO: Implement.
+	 *
+	 * Suggested approach:
+	 *   1. For each depth pixel (px, py) with valid depth Z (mm):
+	 *        - Unproject to camera space using depth intrinsics:
+	 *            X_cam = (px - Cx) * Z / Fx
+	 *            Y_cam = (py - Cy) * Z / Fy
+	 *            Z_cam = Z
+	 *          (Cx, Cy, Fx, Fy available from CameraController->CameraConfig.DepthConfig)
+	 *        - Transform to world space using GetActorTransform() (camera transform).
+	 *   2. Compute the signed distance from the world point to the screen plane:
+	 *        dist = dot(worldPoint - ScreenTransform.GetLocation(), ScreenTransform.GetUnitAxis(EAxis::X))
+	 *   3. If 0 <= dist <= TouchThresholdCm, the point is a touch candidate in front of the screen.
+	 *   4. Project the world point onto the screen plane and compute normalised UV coords:
+	 *        U = dot(localPoint, ScreenTransform.GetUnitAxis(EAxis::Y)) / ScreenWidthCm  + 0.5
+	 *        V = -dot(localPoint, ScreenTransform.GetUnitAxis(EAxis::Z)) / ScreenHeightCm + 0.5
+	 *   5. If U and V are in [0, 1], add FVector2D(U, V) to OutNormalisedTouches.
+	 *   6. Cluster nearby candidates (similar to FBlobTracker::ExtractBlobs) to collapse
+	 *      multiple pixels from the same finger into a single touch point.
+	 */
+	void DetectTouches(const FOrbbecFrame& DepthFrame, TArray<FVector2D>& OutNormalisedTouches) const;
+
+	/**
+	 * Maps a normalised [0,1]x[0,1] screen position to a grid cell.
+	 * Returns false if the position is outside the screen bounds.
+	 */
+	bool NormalisedPosToCell(const FVector2D& NormPos, FScreenGridCell& OutCell) const;
+
+	/**
+	 * Reconciles the new touch positions against the previous frame's touched cells
+	 * and fires OnCellTouched / OnCellReleased as appropriate.
+	 */
+	void UpdateTouchedCells(const TArray<FVector2D>& NormalisedTouches);
+};

--- a/FlowerBeds/Source/FlowerBeds/TouchScreenSettings.h
+++ b/FlowerBeds/Source/FlowerBeds/TouchScreenSettings.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DeveloperSettings.h"
+#include "OrbbecSensor/Device/OrbbecCameraController.h"
+
+#include "TouchScreenSettings.generated.h"
+
+USTRUCT(BlueprintType)
+struct FTouchScreenConfig
+{
+	GENERATED_BODY()
+
+	/**
+	 * Logical name identifying this screen. Matched against ATouchScreen::ScreenName at runtime.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Config, Category = "Touch Screen")
+	FName Name = NAME_None;
+
+	/**
+	 * World-space position of the Orbbec camera observing this screen (cm).
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Config, Category = "Touch Screen")
+	FVector CameraPosCm = FVector::ZeroVector;
+
+	/**
+	 * Rotation of the camera. +X faces into the scene (toward the screen surface).
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Config, Category = "Touch Screen")
+	FRotator CameraRotation = FRotator::ZeroRotator;
+
+	/**
+	 * World-space position of the centre of the physical screen surface (cm).
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Config, Category = "Touch Screen")
+	FVector ScreenPosCm = FVector::ZeroVector;
+
+	/**
+	 * Orientation of the screen surface. +X is the outward-facing normal (toward the viewer),
+	 * +Y is screen-right, +Z is screen-up.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Config, Category = "Touch Screen")
+	FRotator ScreenRotation = FRotator::ZeroRotator;
+
+	/**
+	 * Physical width of the projected screen area (cm).
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Config, Category = "Touch Screen")
+	float WidthCm = 100.f;
+
+	/**
+	 * Physical height of the projected screen area (cm).
+	 * Default is approximately 6 feet (183 cm).
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Config, Category = "Touch Screen")
+	float HeightCm = 183.f;
+
+	/**
+	 * How close (cm) a depth-camera point must be in front of the screen plane to
+	 * register as a touch. Tune this for the physical screen and camera setup.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Config, Category = "Touch Screen")
+	float TouchThresholdCm = 5.f;
+
+	/**
+	 * Orbbec camera configuration. Depth stream must be enabled; colour and IR are optional.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Config, Category = "Touch Screen")
+	FOrbbecCameraConfig CameraConfig;
+};
+
+UCLASS(Config = Game, DefaultConfig, meta = (DisplayName = "Touch Screen Settings"))
+class FLOWERBEDS_API UTouchScreenSettings : public UDeveloperSettings
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(EditAnywhere, Config, Category = "Touch Screen")
+	TArray<FTouchScreenConfig> TouchScreens;
+};


### PR DESCRIPTION
## What's here

Scaffolding for the CAPTCHA touch screen: a 6-foot CRT/projector surface observed by a second Orbbec depth camera. Three new files, no changes to existing code.

### `TouchScreenSettings.h`
`UTouchScreenSettings` / `FTouchScreenConfig` — mirrors the `BlobTrackerSettings` pattern. Config lives in `DefaultGame.ini` under `[/Script/FlowerBeds.TouchScreenSettings]`. Key fields:

| Field | Purpose |
|---|---|
| `CameraPosCm` / `CameraRotation` | Where the Orbbec camera is mounted |
| `ScreenPosCm` / `ScreenRotation` | Where the physical screen surface is (+X = outward normal) |
| `WidthCm` / `HeightCm` | Physical projected area (default 100 × 183 cm) |
| `TouchThresholdCm` | How close a depth point must be in front of the screen to count as a touch (default 5 cm) |
| `CameraConfig` | `FOrbbecCameraConfig` — depth stream must be enabled |

### `TouchScreen.h` / `TouchScreen.cpp`
`ATouchScreen` actor. Place a Blueprint subclass in the level and set `ScreenName` to match the config entry.

- **`SetGrid(Rows, Cols)`** — call before each CAPTCHA challenge; fires `OnCellReleased` for any currently-held cells then resets state
- **`OnCellTouched`** — broadcasts `(FScreenGridCell, FVector2D NormalisedPos)` when a cell goes from untouched → touched
- **`OnCellReleased`** — broadcasts `(FScreenGridCell)` when a cell goes from touched → untouched
- Grid cells are `(Row, Col)`, zero-based, row 0 = top, col 0 = left
- Touch positions are normalised `[0,1]×[0,1]` (origin top-left)
- Actor transform = camera transform; screen plane is stored separately as `ScreenTransform`

### What's stubbed
`DetectTouches()` returns an empty array. The header has a detailed implementation note covering the full depth-unproject → plane-distance → UV-coordinate → clustering pipeline — enough to implement without needing to re-derive the geometry.

## To wire up

1. Once the screen is physically placed, add to `DefaultGame.ini`:
```ini
[/Script/FlowerBeds.TouchScreenSettings]
+TouchScreens=(Name="CaptchaScreen",CameraPosCm=(...),CameraRotation=(...),ScreenPosCm=(...),ScreenRotation=(...),WidthCm=...,HeightCm=183.0,TouchThresholdCm=5.0,CameraConfig=(...))
```
2. Create `BP_TouchScreen` (Blueprint subclass of `ATouchScreen`), place in level, set `ScreenName="CaptchaScreen"`
3. Implement `DetectTouches()` following the approach in `TouchScreen.h`
4. Bind `OnCellTouched` / `OnCellReleased` in the CAPTCHA Blueprint logic

https://claude.ai/code/session_01Y6wiijdkMwmF3uMgtRzckj