### PR TITLE
Migrate from Unreal Engine to Python show control system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,13 +6,14 @@ AI assistant guide for the **CommunityGarden** codebase — show control softwar
 
 ## Project Overview
 
-This is an **Unreal Engine 5** show control system that uses computer vision (Orbbec depth camera) to detect people and drive physical flower servo motors in response. The system:
+This is a **Python** show control system that uses computer vision (Orbbec depth camera) to detect people and drive physical flower servo motors in response. The system:
 
 1. Captures depth frames from an Orbbec camera
-2. Detects human-presence blobs in 3D space via the `IIVision` plugin
-3. Maps blobs to nearby flower clusters
-4. Sends OSC messages over Ethernet to Arduino motor controllers
-5. Arduino controllers drive Dynamixel servos to rotate physical flowers toward detected people
+2. Detects human-presence blobs in 3D space via background-subtraction + connected-component analysis
+3. Stabilizes blob tracks across frames using greedy nearest-neighbour matching and EMA smoothing
+4. Maps stable blob positions to nearby flower clusters
+5. Sends OSC messages over UDP to Arduino motor controllers
+6. Arduino controllers drive Dynamixel servos to rotate physical flowers toward detected people
 
 ---
 
@@ -20,37 +21,23 @@ This is an **Unreal Engine 5** show control system that uses computer vision (Or
 
 ```
 CommunityGarden/
-├── FlowerBeds/                    # Main Unreal Engine 5 project
-│   ├── FlowerBeds.uproject        # UE5 project file (EngineAssociation: "UE-II")
-│   ├── Config/                    # UE config files (INI)
-│   │   ├── DefaultGame.ini        # Runtime settings: controllers, modules, blob trackers
-│   │   ├── DefaultEngine.ini      # Rendering, map, engine settings
-│   │   ├── DefaultInput.ini       # Input bindings
-│   │   └── DefaultEditor.ini      # Editor preferences
-│   ├── Content/                   # UE assets (Blueprints, Maps, Materials) — tracked via Git LFS
-│   ├── Source/
-│   │   └── FlowerBeds/            # Main C++ game module
-│   │       ├── FlowerBeds.Build.cs
-│   │       ├── FlowerBedCoordinator.h/.cpp   # Top-level orchestrator Actor
-│   │       ├── FlowerBedSettings.h           # UDeveloperSettings — config entry point
-│   │       ├── OrbbecBlobTracker.h/.cpp      # Actor: camera input + blob detection
-│   │       ├── FlowerModule.h/.cpp           # Actor: physical module with clusters
-│   │       ├── FlowerCluster.h/.cpp          # Actor: individual cluster driving one motor
-│   │       ├── FlowerController.h/.cpp       # UObject: OSC client for one controller board
-│   │       ├── OrbbecToVisionHelpers.h/.cpp  # Data conversion utilities
-│   │       └── LookCoordinator.h/.cpp        # Gaze/attention direction logic
-│   └── Plugins/
-│       ├── IIVision/              # Impractical Instruments blob-tracking library
-│       ├── OrbbecSensor/          # Orbbec SDK wrapper (Win64 only; delay-loads OrbbecSDK.dll)
-│       └── RiderLink/             # JetBrains IDE integration (pre-included, disabled by default)
+├── ShowControl/
+│   └── FlowerBeds/            # Python show-control application
+│       ├── main.py            # Entry point and main loop
+│       ├── flower_beds.py     # Core logic: Coordinator, FlowerModule, FlowerCluster
+│       ├── flower_controller.py  # OSC client for one controller board
+│       ├── blob_tracker.py    # Depth-frame blob detection (background subtraction + 3D unproject)
+│       ├── blob_stabilizer.py # Cross-frame tracking with EMA smoothing
+│       ├── camera.py          # Orbbec camera + MockCamera abstraction
+│       ├── transforms.py      # UE-style coordinate math (UETransform, UERotator, etc.)
+│       ├── visualizer.py      # FastAPI/WebSocket live top-down debug view
+│       ├── settings.json      # Runtime configuration (cameras, modules, controllers)
+│       └── requirements.txt   # Python dependencies
 ├── Firmware/
-│   ├── FlowerBeds_Follow_ServoController/   # Arduino sketch: receives OSC → drives Dynamixel servos
-│   └── Dynamixel_Config/                   # Arduino sketch: one-time Dynamixel ID/baud configuration
-├── Scripts/
-│   └── InstalledEngineBuild.ps1   # PowerShell: builds a Win64 UE Installed Build from source
+│   └── FlowerBeds_Follow_ServoController/   # Arduino sketch: receives OSC → drives Dynamixel servos
 ├── TouchOSC/
-│   └── FlowerBedTester.tosc       # TouchOSC layout for manual motor testing
-├── .gitattributes                 # Git LFS rules for UE binary assets
+│   └── FlowerBedTester.tosc   # TouchOSC layout for manual motor testing
+├── .gitattributes
 └── README.md
 ```
 
@@ -60,136 +47,173 @@ CommunityGarden/
 
 | Layer | Technology |
 |---|---|
-| Game engine | Unreal Engine 5 (`UE-II` — custom installed build) |
-| Primary language | C++ (UE conventions) |
-| Build system | Unreal Build Tool (UBT) + `.Build.cs` files |
-| Computer vision | Custom `IIVision` plugin (blob detection from depth frames) |
-| Depth camera | Orbbec SDK v2 via `OrbbecSensor` plugin |
-| Networking | OSC over UDP (UE `OSC` module + Arduino `OSCMessage` library) |
+| Primary language | Python 3.11+ |
+| Computer vision | Custom numpy/scipy blob tracker (background subtraction + pinhole unproject) |
+| Depth camera | Orbbec SDK v2 via `pyorbbecsdk2` |
+| Networking | OSC over UDP via `python-osc` |
+| Visualizer | FastAPI + WebSocket + embedded browser client (uvicorn) |
 | Motor hardware | Dynamixel servos via `Dynamixel2Arduino` library |
 | Microcontroller | OpenRB-150 (SAMD21) running Arduino firmware |
 | Control UI | TouchOSC layout for manual testing |
-| Build scripts | PowerShell (Windows only) |
 
 ---
 
-## C++ Code Conventions
+## Python Code Conventions
 
-This project follows standard Unreal Engine C++ conventions throughout.
+### Module Responsibilities
 
-### Naming Prefixes
-
-| Prefix | Meaning |
+| File | Responsibility |
 |---|---|
-| `A` | Actor subclass (e.g., `AFlowerBedCoordinator`, `AFlowerModule`) |
-| `U` | UObject subclass (e.g., `UFlowerController`, `UFlowerBedSettings`) |
-| `F` | Plain struct (e.g., `FFlowerClusterConfig`, `FFlowerControllerConfig`) |
-| `I` | Interface |
-| `T` | Template class |
+| `main.py` | Argument parsing, config loading, main frame loop, wiring everything together |
+| `flower_beds.py` | `Coordinator`, `FlowerModule`, `FlowerCluster` — cluster assignment and yaw calculation |
+| `flower_controller.py` | `FlowerController` — wraps `python-osc` UDP client |
+| `blob_tracker.py` | `BlobTracker` — stateful per-camera blob detection; `Blob2D`, `Blob3D`, `FramePacket` |
+| `blob_stabilizer.py` | `BlobStabilizer` — cross-frame ID assignment and EMA de-jittering |
+| `camera.py` | `OrbbecCamera`, `MockCamera` — frame iterator abstraction |
+| `transforms.py` | `UETransform`, `UERotator`, coordinate conversion helpers |
+| `visualizer.py` | FastAPI WebSocket server; `broadcast(state)` called each frame |
 
-### UPROPERTY / UFUNCTION Macros
+### Coordinate System
 
-- Use `UPROPERTY(EditAnywhere, Config, Category = "Flower Beds")` for settings that should be editable in-editor and persisted to INI.
-- Use `UPROPERTY(Transient)` for runtime-only objects that should not be serialized (e.g., spawned actors, OSC clients).
-- Use `UFUNCTION(BlueprintCallable)` for methods that may need to be called from Blueprint.
-- Use `DECLARE_MULTICAST_DELEGATE_*` for native-only callbacks; use `DECLARE_DYNAMIC_MULTICAST_DELEGATE_*` for Blueprint-assignable delegates.
+All world positions use UE-style coordinates: **X=forward, Y=right, Z=up, centimetres**.
 
-### Smart Pointers
+Camera-space coordinates (from the depth sensor) use: **X=right, Y=down, Z=forward, metres**.
 
-- Use `TObjectPtr<UType>` for GC-tracked UObject references.
-- Use `TArray<>`, `TMap<>`, etc. — never raw STL containers.
-- Avoid raw pointers to UObjects; prefer `TObjectPtr` or `TWeakObjectPtr` depending on ownership.
+`Blob3D.world_pos_cm()` handles the conversion between these spaces.
+
+### Config Types
+
+Config dataclasses in `flower_beds.py` mirror the former C++ settings structs:
+
+| Python class | Former C++ struct |
+|---|---|
+| `ClusterConfig` | `FFlowerClusterConfig` |
+| `ModuleConfig` | `FFlowerModuleConfig` |
+| `ControllerConfig` | `FFlowerControllerConfig` |
+| `CameraConfig` | (formerly in `UBlobTrackerSettings`) |
 
 ### Logging
 
-Use the custom log category for this project:
+Use the named logger throughout:
 
-```cpp
-UE_LOG(LogFlowerBeds, Log, TEXT("..."));
-UE_LOG(LogFlowerBeds, Warning, TEXT("..."));
-UE_LOG(LogFlowerBeds, Error, TEXT("..."));
+```python
+import logging
+log = logging.getLogger("flower_beds")
+log.info("...")
+log.warning("...")
+log.error("...")
 ```
-
-### Header Guards
-
-Use `#pragma once` — never `#ifndef` guards.
-
-### Module PCH
-
-All modules use `PCHUsage = PCHUsageMode::UseExplicitOrSharedPCHs`. Always include `CoreMinimal.h` explicitly rather than relying on PCH.
-
-### RTTI
-
-Both `IIVision` and `OrbbecSensor` set `bUseRTTI = true` in their `.Build.cs`. The main `FlowerBeds` module does not require RTTI.
 
 ---
 
 ## Architecture & Key Patterns
 
+### Main Loop
+
+`main.py` drives the pipeline each frame:
+
+```
+camera.frames()
+  → BlobTracker.detect(frame)          # background subtraction + 3D unproject
+  → transform_position(camera_transform, blob.world_pos_cm())   # camera → world space
+  → BlobStabilizer.update(raw_positions)  # ID assignment + EMA smoothing
+  → Coordinator.process_world_positions(tracked_positions)       # cluster assignment
+  → FlowerController.send_all(commands)   # OSC → Arduino
+  → visualizer.broadcast(state)           # WebSocket → browser
+```
+
+### Blob Detection Pipeline
+
+`BlobTracker` (in `blob_tracker.py`) runs per frame once calibrated:
+
+1. **Background subtraction** — per-pixel depth delta vs median background
+2. **Majority filter ×2** — 3×3 neighbourhood despeckle
+3. **Connected components** — 8-connected blobs via `scipy.ndimage.label`
+4. **3D unproject** — pinhole model, median-Z windowing, camera → UE coordinate conversion
+
+Calibration collects `N` frames (configurable via `calibration_frames` in `settings.json`) to build a per-pixel median background and validity mask.
+
+### Blob Stabilization
+
+`BlobStabilizer` (in `blob_stabilizer.py`) runs after detection:
+- Greedy nearest-neighbour matching within `max_match_dist_cm`
+- EMA smoothing: `pos = alpha * new + (1 - alpha) * prev`
+- Drops tracks missing for more than `max_miss_frames` frames
+- Suppresses new tracks until seen for `min_confirm_frames` consecutive frames
+
 ### Coordinator Pattern
 
-`AFlowerBedCoordinator` is the top-level Actor placed in the level. On `BeginPlay` it reads settings and spawns:
-- One `AOrbbecBlobTracker` per configured camera
-- One `AFlowerModule` per configured physical module
-- One `UFlowerController` per configured motor controller board
-
-It subscribes to `AOrbbecBlobTracker::OnBlobDetectionResult` and routes detection results to `AFlowerModule::UpdateClusterTargets`, which in turn calls `UFlowerController::SendFlowerRotation` via OSC.
-
-### Configuration as Data
-
-All runtime configuration lives in `UFlowerBedSettings` (a `UDeveloperSettings` subclass, `Config=Game`). This means settings are:
-- Editable in the UE Editor under **Edit → Project Settings → Flower Beds**
-- Persisted to `FlowerBeds/Config/DefaultGame.ini`
-- Readable at runtime via `GetDefault<UFlowerBedSettings>()`
-
-The same pattern is used for `UBlobTrackerSettings`.
-
-**Do not hardcode network addresses, positions, or motor IDs** — they all belong in settings structs.
+`Coordinator` holds a list of `FlowerModule` objects. Each `FlowerModule` holds a list of `FlowerCluster` objects. Each frame:
+1. `Coordinator.process_world_positions(positions)` fans out to all modules
+2. `FlowerModule.update(positions)` fans out to all clusters
+3. `FlowerCluster.update(positions)` finds nearest blob, computes yaw, returns `MotorCommand`
 
 ### OSC Communication Flow
 
 ```
-UE (FlowerController) --UDP/OSC--> Arduino (192.168.1.50:9000)
+Python (FlowerController) --UDP/OSC--> Arduino (192.168.1.50:9000)
   address: /cg/ff/rot
-  args:    [int motorId, float rotationDeg]
+  args:    [int motor_id, float rotation_deg]
 ```
 
-The Arduino firmware listens on that address and calls `setRotDeg()` to drive the target Dynamixel servo.
+The Arduino firmware listens on `/cg/ff/rot` and calls `setRotDeg()` to drive the target Dynamixel servo.
 
-### Blob Detection Pipeline
+### Visualizer
 
-```
-Orbbec Camera
-  → FOrbbecFrame (depth at 640×400, 30fps)
-  → AOrbbecBlobTracker::OnFramesReceived()
-  → OrbbecToVisionHelpers (converts to IIVision frame format)
-  → II::Vision::FBlobTracker::Detect()
-  → FBlobTracker::FDetectionResult (array of FBlob3D with 3D world positions)
-  → AFlowerBedCoordinator::OnBlobDetectionResult()
-  → AFlowerModule::UpdateClusterTargets()
-  → AFlowerCluster::UpdateClusterTargets() → nearest-blob angle calculation
-  → UFlowerController::SendFlowerRotation()
-```
+`visualizer.py` runs a FastAPI WebSocket server (default port 8765). Each frame, `broadcast(state)` pushes a JSON snapshot of blobs, clusters, and camera positions to all connected browser clients. Open `http://<show-computer-ip>:8765` to see the live top-down view.
 
 ---
 
 ## Configuration Reference
 
-### DefaultGame.ini Structure
+### settings.json Structure
 
-```ini
-[/Script/FlowerBeds.FlowerBedSettings]
-+FlowerControllers=(IPAddress="192.168.1.50",Port=9000)
-+FlowerModules=(RegistrationPointPosCm=(...),Rotation=(...),FlowerClusters=(...))
+```json
+{
+  "calibration_frames": 60,
 
-[/Script/FlowerBeds.BlobTrackerSettings]
-+BlobTrackers=(Name="...",PosCm=(...),Rotation=(...),CameraConfig=(...))
+  "stabilizer": {
+    "max_match_dist_cm": 80.0,
+    "smoothing_alpha": 0.3,
+    "max_miss_frames": 8,
+    "min_confirm_frames": 2
+  },
+
+  "controllers": [
+    { "ip": "192.168.1.50", "port": 9000 }
+  ],
+
+  "modules": [
+    {
+      "registration_point_cm": [-200.0, 100.0, 0.0],
+      "rotation": {"pitch": 0, "yaw": 0, "roll": 0},
+      "clusters": [
+        {
+          "motor_id": 1,
+          "pos_offset_cm": [0.0, 40.0, 0.0],
+          "rotation_offset": {"pitch": 0, "yaw": 0, "roll": 0}
+        }
+      ]
+    }
+  ],
+
+  "cameras": [
+    {
+      "name": "Entrance",
+      "pos_cm": [-300.0, 0.0, 200.0],
+      "rotation": {"pitch": -30.0, "yaw": 0.0, "roll": 0.0},
+      "serial": "CPCG853000CB",
+      "width": 640,
+      "height": 400,
+      "framerate": 10
+    }
+  ]
+}
 ```
 
-- Use `+` prefix to append to array properties.
-- `RegistrationPointPosCm` is the physical anchor point of each module in centimeters relative to the chosen world origin.
-- `MotorId` in `FFlowerClusterConfig` must match the Dynamixel servo ID set via `Dynamixel_Config` firmware.
-- Camera `DeviceSerialNumber` must match the serial printed on the Orbbec device.
+- `motor_id` must match the Dynamixel servo ID configured via the `Dynamixel_Config` firmware.
+- `serial` must match the serial printed on the Orbbec device. Leave empty to use the first detected camera.
+- `registration_point_cm` is the physical anchor of each module in world space (centimetres).
 
 ### Network Setup
 
@@ -199,49 +223,56 @@ Orbbec Camera
 
 ---
 
-## Build & Development Workflow
+## Running the Show Control
 
 ### Prerequisites
 
-- Windows (Win64 is the only supported target platform)
-- Unreal Engine 5 installed (engine association `"UE-II"` — see registry key for installed path)
-- Visual Studio 2022 with C++ game development workload
-- Arduino IDE or PlatformIO for firmware
+- Python 3.11+
+- Orbbec SDK v2 (for real camera; not needed in mock mode)
 
-### Opening the Project
+### Install dependencies
 
-1. Double-click `FlowerBeds/FlowerBeds.uproject` to open in UE5 Editor.
-2. On first open UBT will compile the `FlowerBeds`, `IIVision`, and `OrbbecSensor` modules.
-3. Generate Visual Studio solution: **File → Generate Visual Studio Project Files** or run `GenerateProjectFiles.bat`.
-
-### Building (Editor)
-
-Build from Visual Studio (`Development Editor` configuration, `Win64`) or use the UE toolbar.
-
-### Building a Packaged / Installed Build
-
-Use the provided PowerShell script to create a redistributable Win64 engine build:
-
-```powershell
-.\Scripts\InstalledEngineBuild.ps1 -EngineRoot "D:\UE\UnrealEngine"
-# Optional flags:
-#   -Clean              # remove previous build artifacts
-#   -WithDDC $true      # include Derived Data Cache
-#   -GameConfigurations @('Development','Shipping')
+```bash
+cd ShowControl/FlowerBeds
+pip install -r requirements.txt
 ```
 
-Output goes to `<EngineRoot>\Engine\LocalBuilds\Engine\Windows\`.
+### Run (real hardware)
 
-### Packaging the Game
+```bash
+python main.py --config settings.json
+```
 
-Use the standard UE packaging workflow (File → Package Project → Windows) or UAT. `OrbbecSDK.dll` is automatically staged next to the executable via `RuntimeDependencies` in `OrbbecSensor.Build.cs`.
+### Run (mock camera, no hardware)
 
-### Firmware
+```bash
+python main.py --config settings.json --mock --no-osc
+```
+
+### Run (headless, no visualizer)
+
+```bash
+python main.py --config settings.json --no-visualizer
+```
+
+### CLI flags
+
+| Flag | Description |
+|---|---|
+| `--config PATH` | Path to settings JSON (default: `settings.json`) |
+| `--mock` | Use mock camera (random blobs, no hardware required) |
+| `--no-osc` | Disable OSC output to Arduino |
+| `--no-visualizer` | Disable WebSocket visualizer server |
+| `--visualizer-port N` | Visualizer HTTP port (default: 8765) |
+| `--verbose` / `-v` | Enable DEBUG logging |
+
+---
+
+## Firmware
 
 Open `.ino` files in Arduino IDE:
 
 - **`FlowerBeds_Follow_ServoController`** — deploy to each OpenRB-150 controller board. Update the `ip` and `mac` variables for each board if running multiple controllers.
-- **`Dynamixel_Config`** — one-time utility to configure Dynamixel servo IDs and baud rates before deployment.
 
 Required Arduino libraries:
 - `Dynamixel2Arduino`
@@ -250,36 +281,21 @@ Required Arduino libraries:
 
 ---
 
-## Content & Assets
-
-All content is under `FlowerBeds/Content/` and tracked via **Git LFS** (`.gitattributes` rules cover `.uasset`, `.umap`, `.fbx`, `.pdb`, and other binary types).
-
-Key assets:
-- `BP_FlowerBedCoordinator` — Blueprint subclass of `AFlowerBedCoordinator`; place one in the level
-- `BP_OrbbecBlobTracker` — Blueprint subclass; set `BlobTrackerClass` on the coordinator
-- `BP_FlowerModule`, `BP_FlowerCluster`, `BP_Flower` — physical hierarchy
-- `FlowerBeds.umap` — main production level
-- `CameraTest.umap` — debug level for camera/blob visualization
-- `M_DepthIRDebug`, `M_BlobOverlayDebug` — debug visualization materials
-
----
-
 ## No Formal Tests or CI
 
 There is currently no automated test suite and no CI/CD pipeline. Verification is done by:
-1. Running in-editor with a connected Orbbec camera and the debug maps
-2. Using the `CameraTest.umap` level and debug visualizers (`UArrayVisualizer`, `UBlobArrayVisualizer`)
+1. Running with `--mock --no-osc` to exercise the full pipeline without hardware
+2. Connecting the live visualizer at `http://<show-computer-ip>:8765` to observe blob tracking
 3. Using the TouchOSC layout (`TouchOSC/FlowerBedTester.tosc`) for manual motor validation
 
-When making changes, manually verify the full pipeline: camera → blob detection → OSC → servo movement.
+When making changes, manually verify the full pipeline: camera → blob detection → stabilization → OSC → servo movement.
 
 ---
 
 ## Git Workflow
 
 - **Main branch:** `main`
-- **Feature branches:** use descriptive names (e.g., `claude/add-claude-documentation-QRcEL`)
-- **Large binary assets** are tracked with Git LFS — never commit binaries without LFS configured
+- **Feature branches:** use descriptive names (e.g., `claude/update-claude-docs-0DCew`)
 - No pre-commit hooks are installed; review changes manually before committing
 - Commit messages are informal/descriptive (not conventional commits format)
 
@@ -291,10 +307,9 @@ git push -u origin <branch-name>
 
 ## Key Things to Know Before Making Changes
 
-1. **Platform is Win64 only.** The `OrbbecSensor` plugin has a Win64 guard in its `.Build.cs`; do not attempt to build for other platforms.
-2. **Settings are INI-driven.** Avoid adding hardcoded values for IPs, ports, positions, or motor IDs — add them to the appropriate `UDeveloperSettings` subclass instead.
-3. **OSC address is `/cg/ff/rot`.** The UE side (`FlowerController.cpp`) and the Arduino firmware (`FlowerBeds_Follow_ServoController.ino`) must agree on this address. Change it in both places if needed.
-4. **Dynamixel motor IDs must match config.** `FFlowerClusterConfig::MotorId` must match the ID programmed into the servo hardware.
-5. **`bUseRTTI = true` is required** in `IIVision` and `OrbbecSensor` build rules — do not remove it.
-6. **Do not modify `RiderLink` plugin.** It is a prebuilt JetBrains plugin; update it as a whole unit if needed.
-7. **Git LFS must be active** before cloning or pulling — otherwise binary assets will be broken stubs.
+1. **OSC address is `/cg/ff/rot`.** `flower_controller.py` and the Arduino firmware (`FlowerBeds_Follow_ServoController.ino`) must agree on this address — change it in both places if needed.
+2. **Coordinate system is UE-style.** World space uses X=forward, Y=right, Z=up in centimetres. Camera space uses X=right, Y=down, Z=forward in metres. `Blob3D.world_pos_cm()` converts between them.
+3. **Dynamixel motor IDs must match config.** `ClusterConfig.motor_id` in `settings.json` must match the ID programmed into the servo hardware.
+4. **Do not hardcode network addresses, positions, or motor IDs** — they all belong in `settings.json`.
+5. **Mock mode** (`--mock`) works without any hardware and is the fastest way to test logic changes.
+6. **`pyorbbecsdk2`** is only needed for real camera operation; mock mode runs without it installed.


### PR DESCRIPTION
## Summary

This is a major architectural refactor that migrates the CommunityGarden show control system from Unreal Engine 5 (C++) to Python 3.11+. The core functionality remains the same—detecting people via depth camera and driving servo motors—but the implementation is now lightweight, cross-platform, and easier to iterate on.

## Key Changes

- **Language & Framework:** Replaced UE5 C++ codebase with Python modules (`flower_beds.py`, `blob_tracker.py`, `blob_stabilizer.py`, `camera.py`, `transforms.py`, `flower_controller.py`, `visualizer.py`)
- **Vision Pipeline:** Replaced `IIVision` plugin with custom numpy/scipy blob detection (background subtraction + connected-component analysis + 3D unprojection)
- **Blob Tracking:** Implemented greedy nearest-neighbour matching with EMA smoothing in `BlobStabilizer` for cross-frame stability
- **Configuration:** Replaced INI-based `UDeveloperSettings` with JSON config file (`settings.json`) for cameras, modules, clusters, and controllers
- **Networking:** Maintained OSC/UDP communication to Arduino; now via `python-osc` library
- **Visualization:** Added FastAPI WebSocket server (`visualizer.py`) for live top-down debug view in browser
- **Documentation:** Updated CLAUDE.md with Python conventions, module responsibilities, architecture patterns, and CLI usage

## Implementation Details

- **Coordinate System:** Preserved UE-style world coordinates (X=forward, Y=right, Z=up, cm) with helper functions in `transforms.py` for camera↔world conversion
- **Calibration:** `BlobTracker` collects configurable number of frames to build per-pixel median background before detection begins
- **Stabilization:** `BlobStabilizer` suppresses jitter with configurable EMA alpha and enforces minimum confirmation frames before tracks are emitted
- **Main Loop:** `main.py` orchestrates frame capture → detection → stabilization → cluster assignment → OSC output → visualization broadcast
- **Mock Mode:** `--mock` flag enables testing without hardware; `--no-osc` disables Arduino output for dry runs
- **Headless Operation:** `--no-visualizer` flag allows deployment without WebSocket server overhead

All motor IDs, network addresses, and positions remain configurable in `settings.json`; no hardcoded values.

https://claude.ai/code/session_01KNBJoghX6hJpxZv1nS13Dx