### PR TITLE
Add Playing The Pipes music system Max patch stubs

### DIFF
--- a/ShowControl/PlayingThePipes/Music/PlayingThePipes.maxpat
+++ b/ShowControl/PlayingThePipes/Music/PlayingThePipes.maxpat
@@ -1,0 +1,900 @@
+{
+	"patcher" : 	{
+		"fileversion" : 1,
+		"appversion" : 		{
+			"major" : 8,
+			"minor" : 6,
+			"revision" : 2,
+			"architecture" : "x64",
+			"modernui" : 1
+		},
+		"classnamespace" : "dsp.toplevel",
+		"rect" : [ 60, 60, 1280, 940 ],
+		"bglocked" : 0,
+		"openinpresentation" : 0,
+		"default_fontsize" : 12.0,
+		"default_fontface" : 0,
+		"default_fontname" : "Arial",
+		"gridonopen" : 1,
+		"gridsize" : [ 15.0, 15.0 ],
+		"gridsnaponopen" : 1,
+		"objectsnaptoobjects" : 0,
+		"statusbarvisible" : 2,
+		"toolbarvisible" : 1,
+		"description" : "Playing The Pipes — top-level music system. Receives OSC (8 encoders + 8 switches) from water-valve hardware. Drives: audio clip launcher, MIDI clip launcher + synths, 4-channel spatial output, fog machines, and LEDs.",
+		"boxes" : [
+			{
+				"box" : 				{
+					"id" : "obj-1",
+					"maxclass" : "comment",
+					"text" : "Playing The Pipes — Music System",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 20.0, 15.0, 500.0, 28.0 ],
+					"fontsize" : 18.0,
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-2",
+					"maxclass" : "comment",
+					"text" : "OSC input (8 encoders, 8 switches) → audio/MIDI clip launchers → synths → FX → 4-ch spatial output + fog/LED",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 20.0, 47.0, 900.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-3",
+					"maxclass" : "comment",
+					"text" : "All abstractions live in the same folder as this patch. Open each to inspect or extend its internals.",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 20.0, 67.0, 800.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-4",
+					"maxclass" : "comment",
+					"text" : "── INPUT ──────────────────────────────────────────────────────────────────────",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 20.0, 100.0, 800.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-5",
+					"maxclass" : "newobj",
+					"text" : "pp.osc-in",
+					"numinlets" : 0,
+					"numoutlets" : 2,
+					"outlettype" : [ "", "" ],
+					"patching_rect" : [ 30.0, 125.0, 120.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-6",
+					"maxclass" : "comment",
+					"text" : "outlet 0: encoder data [num 0.0-1.0]   outlet 1: switch data [num 0/1]",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 165.0, 129.0, 500.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-7",
+					"maxclass" : "newobj",
+					"text" : "unpack i f",
+					"numinlets" : 1,
+					"numoutlets" : 2,
+					"outlettype" : [ "int", "float" ],
+					"patching_rect" : [ 30.0, 165.0, 90.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-8",
+					"maxclass" : "newobj",
+					"text" : "unpack i i",
+					"numinlets" : 1,
+					"numoutlets" : 2,
+					"outlettype" : [ "int", "int" ],
+					"patching_rect" : [ 600.0, 165.0, 90.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-9",
+					"maxclass" : "comment",
+					"text" : "encoder num + value",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 130.0, 169.0, 160.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-10",
+					"maxclass" : "comment",
+					"text" : "switch num + state",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 700.0, 169.0, 160.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-11",
+					"maxclass" : "comment",
+					"text" : "── CLIP LAUNCHERS ─────────────────────────────────────────────────────────────",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 20.0, 210.0, 900.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-12",
+					"maxclass" : "comment",
+					"text" : "Switches 1-4 trigger audio clips; switches 5-8 trigger MIDI clips.",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 20.0, 228.0, 600.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-13",
+					"maxclass" : "newobj",
+					"text" : "route 1 2 3 4",
+					"numinlets" : 1,
+					"numoutlets" : 5,
+					"outlettype" : [ "bang", "bang", "bang", "bang", "" ],
+					"patching_rect" : [ 600.0, 248.0, 120.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-14",
+					"maxclass" : "comment",
+					"text" : "route switch 1-4 to audio launcher",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 730.0, 252.0, 280.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-15",
+					"maxclass" : "newobj",
+					"text" : "route 5 6 7 8",
+					"numinlets" : 1,
+					"numoutlets" : 5,
+					"outlettype" : [ "bang", "bang", "bang", "bang", "" ],
+					"patching_rect" : [ 600.0, 280.0, 120.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-16",
+					"maxclass" : "comment",
+					"text" : "route switch 5-8 to MIDI launcher + fog",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 730.0, 284.0, 300.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-17",
+					"maxclass" : "newobj",
+					"text" : "pp.audio-clip-launcher",
+					"numinlets" : 1,
+					"numoutlets" : 2,
+					"outlettype" : [ "signal", "signal" ],
+					"patching_rect" : [ 30.0, 265.0, 200.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-18",
+					"maxclass" : "newobj",
+					"text" : "pp.midi-clip-launcher",
+					"numinlets" : 1,
+					"numoutlets" : 3,
+					"outlettype" : [ "int", "int", "int" ],
+					"patching_rect" : [ 350.0, 265.0, 195.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-19",
+					"maxclass" : "comment",
+					"text" : "outlet 0=L  outlet 1=R",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 240.0, 269.0, 160.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-20",
+					"maxclass" : "comment",
+					"text" : "outlet 0=pitch  1=vel  2=gate",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 555.0, 269.0, 220.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-21",
+					"maxclass" : "comment",
+					"text" : "── SYNTHESIS ──────────────────────────────────────────────────────────────────",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 20.0, 315.0, 900.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-22",
+					"maxclass" : "comment",
+					"text" : "Two synth voices fed by the MIDI clip launcher. Voice 2 is transposed up an octave (+12 semitones).",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 20.0, 333.0, 700.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-23",
+					"maxclass" : "newobj",
+					"text" : "pp.synth",
+					"numinlets" : 3,
+					"numoutlets" : 2,
+					"outlettype" : [ "signal", "signal" ],
+					"patching_rect" : [ 350.0, 358.0, 90.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-24",
+					"maxclass" : "newobj",
+					"text" : "pp.synth",
+					"numinlets" : 3,
+					"numoutlets" : 2,
+					"outlettype" : [ "signal", "signal" ],
+					"patching_rect" : [ 550.0, 358.0, 90.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-25",
+					"maxclass" : "comment",
+					"text" : "voice 1 (root)",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 450.0, 362.0, 110.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-26",
+					"maxclass" : "comment",
+					"text" : "voice 2 (+1 octave)",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 650.0, 362.0, 130.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-27",
+					"maxclass" : "newobj",
+					"text" : "+ 12",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "int" ],
+					"patching_rect" : [ 550.0, 335.0, 50.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-28",
+					"maxclass" : "comment",
+					"text" : "octave up for voice 2",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 610.0, 335.0, 160.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-29",
+					"maxclass" : "comment",
+					"text" : "── MIX BUS ────────────────────────────────────────────────────────────────────",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 20.0, 405.0, 900.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-30",
+					"maxclass" : "comment",
+					"text" : "Sum all audio sources to a stereo bus, then send through the shared effects chain.",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 20.0, 423.0, 700.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-31",
+					"maxclass" : "newobj",
+					"text" : "+~",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 30.0, 448.0, 45.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-32",
+					"maxclass" : "newobj",
+					"text" : "+~",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 90.0, 448.0, 45.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-33",
+					"maxclass" : "newobj",
+					"text" : "+~",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 150.0, 448.0, 45.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-34",
+					"maxclass" : "comment",
+					"text" : "L bus: audio clips + synth voices",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 210.0, 452.0, 260.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-35",
+					"maxclass" : "newobj",
+					"text" : "+~",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 30.0, 480.0, 45.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-36",
+					"maxclass" : "newobj",
+					"text" : "+~",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 90.0, 480.0, 45.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-37",
+					"maxclass" : "newobj",
+					"text" : "+~",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 150.0, 480.0, 45.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-38",
+					"maxclass" : "comment",
+					"text" : "R bus",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 210.0, 484.0, 60.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-39",
+					"maxclass" : "comment",
+					"text" : "── EFFECTS ────────────────────────────────────────────────────────────────────",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 20.0, 520.0, 900.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-40",
+					"maxclass" : "newobj",
+					"text" : "pp.fx-chain",
+					"numinlets" : 2,
+					"numoutlets" : 2,
+					"outlettype" : [ "signal", "signal" ],
+					"patching_rect" : [ 30.0, 545.0, 120.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-41",
+					"maxclass" : "comment",
+					"text" : "gain → HPF → reverb → delay",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 165.0, 549.0, 230.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-42",
+					"maxclass" : "comment",
+					"text" : "── SPATIAL OUTPUT + HARDWARE CONTROL ─────────────────────────────────────────",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 20.0, 590.0, 900.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-43",
+					"maxclass" : "newobj",
+					"text" : "pp.spatial-out",
+					"numinlets" : 2,
+					"numoutlets" : 4,
+					"outlettype" : [ "signal", "signal", "signal", "signal" ],
+					"patching_rect" : [ 30.0, 615.0, 135.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-44",
+					"maxclass" : "comment",
+					"text" : "Ch1=front-L  Ch2=front-R  Ch3=rear-L  Ch4=rear-R",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 180.0, 619.0, 380.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-45",
+					"maxclass" : "newobj",
+					"text" : "pp.fog-led",
+					"numinlets" : 2,
+					"numoutlets" : 0,
+					"patching_rect" : [ 750.0, 615.0, 120.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-46",
+					"maxclass" : "comment",
+					"text" : "inlet 0=fog trigger  inlet 1=LED level (encoder 8)",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 880.0, 619.0, 380.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-47",
+					"maxclass" : "newobj",
+					"text" : "sel 8",
+					"numinlets" : 1,
+					"numoutlets" : 2,
+					"outlettype" : [ "bang", "" ],
+					"patching_rect" : [ 700.0, 558.0, 60.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-48",
+					"maxclass" : "comment",
+					"text" : "switch 8 → fog trigger",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 770.0, 562.0, 200.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-49",
+					"maxclass" : "newobj",
+					"text" : "sel 8",
+					"numinlets" : 1,
+					"numoutlets" : 2,
+					"outlettype" : [ "bang", "" ],
+					"patching_rect" : [ 700.0, 590.0, 60.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-50",
+					"maxclass" : "comment",
+					"text" : "encoder 8 → LED level",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 770.0, 594.0, 200.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-51",
+					"maxclass" : "comment",
+					"text" : "── AUDIO OUTPUT ───────────────────────────────────────────────────────────────",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 20.0, 660.0, 900.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-52",
+					"maxclass" : "newobj",
+					"text" : "dac~ 1 2 3 4",
+					"numinlets" : 4,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 30.0, 685.0, 120.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-53",
+					"maxclass" : "comment",
+					"text" : "hardware channels 1-4  (front-L, front-R, rear-L, rear-R)",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 165.0, 689.0, 450.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-54",
+					"maxclass" : "newobj",
+					"text" : "ezdac~",
+					"numinlets" : 2,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 720.0, 60.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-55",
+					"maxclass" : "comment",
+					"text" : "ezdac~ shown here for development convenience — use dac~ 1 2 3 4 above in performance",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 100.0, 724.0, 700.0, 18.0 ]
+				}
+			}
+		],
+		"lines" : [
+			{
+				"patchline" : 				{
+					"source" : [ "obj-5", 0 ],
+					"destination" : [ "obj-7", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-5", 1 ],
+					"destination" : [ "obj-8", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-8", 0 ],
+					"destination" : [ "obj-13", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-8", 0 ],
+					"destination" : [ "obj-15", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-8", 0 ],
+					"destination" : [ "obj-47", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-7", 0 ],
+					"destination" : [ "obj-49", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-13", 0 ],
+					"destination" : [ "obj-17", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-13", 1 ],
+					"destination" : [ "obj-17", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-13", 2 ],
+					"destination" : [ "obj-17", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-13", 3 ],
+					"destination" : [ "obj-17", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-15", 0 ],
+					"destination" : [ "obj-18", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-15", 1 ],
+					"destination" : [ "obj-18", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-15", 2 ],
+					"destination" : [ "obj-18", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-15", 3 ],
+					"destination" : [ "obj-18", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-18", 0 ],
+					"destination" : [ "obj-23", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-18", 1 ],
+					"destination" : [ "obj-23", 1 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-18", 2 ],
+					"destination" : [ "obj-23", 2 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-18", 0 ],
+					"destination" : [ "obj-27", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-27", 0 ],
+					"destination" : [ "obj-24", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-18", 1 ],
+					"destination" : [ "obj-24", 1 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-18", 2 ],
+					"destination" : [ "obj-24", 2 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-17", 0 ],
+					"destination" : [ "obj-31", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-23", 0 ],
+					"destination" : [ "obj-31", 1 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-31", 0 ],
+					"destination" : [ "obj-33", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-24", 0 ],
+					"destination" : [ "obj-32", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-32", 0 ],
+					"destination" : [ "obj-33", 1 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-17", 1 ],
+					"destination" : [ "obj-35", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-23", 1 ],
+					"destination" : [ "obj-35", 1 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-35", 0 ],
+					"destination" : [ "obj-37", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-24", 1 ],
+					"destination" : [ "obj-36", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-36", 0 ],
+					"destination" : [ "obj-37", 1 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-33", 0 ],
+					"destination" : [ "obj-40", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-37", 0 ],
+					"destination" : [ "obj-40", 1 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-40", 0 ],
+					"destination" : [ "obj-43", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-40", 1 ],
+					"destination" : [ "obj-43", 1 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-43", 0 ],
+					"destination" : [ "obj-52", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-43", 1 ],
+					"destination" : [ "obj-52", 1 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-43", 2 ],
+					"destination" : [ "obj-52", 2 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-43", 3 ],
+					"destination" : [ "obj-52", 3 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-47", 0 ],
+					"destination" : [ "obj-45", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-49", 0 ],
+					"destination" : [ "obj-45", 1 ],
+					"midpoints" : []
+				}
+			}
+		],
+		"parameters" : {},
+		"dependency_cache" : [],
+		"autosave" : 0
+	}
+}

--- a/ShowControl/PlayingThePipes/Music/pp.audio-clip-launcher.maxpat
+++ b/ShowControl/PlayingThePipes/Music/pp.audio-clip-launcher.maxpat
@@ -1,0 +1,521 @@
+{
+	"patcher" : 	{
+		"fileversion" : 1,
+		"appversion" : 		{
+			"major" : 8,
+			"minor" : 6,
+			"revision" : 2,
+			"architecture" : "x64",
+			"modernui" : 1
+		},
+		"classnamespace" : "dsp.toplevel",
+		"rect" : [ 100, 100, 780, 620 ],
+		"bglocked" : 0,
+		"openinpresentation" : 0,
+		"default_fontsize" : 12.0,
+		"default_fontface" : 0,
+		"default_fontname" : "Arial",
+		"gridonopen" : 1,
+		"gridsize" : [ 15.0, 15.0 ],
+		"gridsnaponopen" : 1,
+		"objectsnaptoobjects" : 0,
+		"statusbarvisible" : 2,
+		"toolbarvisible" : 1,
+		"description" : "4-slot audio clip launcher. Inlet 0: slot trigger (int 1-4 to play, 0 to stop all). Outlets: L/R stereo audio mix. Slots use sfplay~ — load audio files by double-clicking each sfplay~ and choosing 'Set...'.",
+		"boxes" : [
+			{
+				"box" : 				{
+					"id" : "obj-1",
+					"maxclass" : "comment",
+					"text" : "pp.audio-clip-launcher — 4-Slot Audio Clip Launcher",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 15.0, 15.0, 480.0, 22.0 ],
+					"fontsize" : 14.0,
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-2",
+					"maxclass" : "comment",
+					"text" : "Send int 1-4 to trigger a slot; 0 stops all. Load audio via each sfplay~ object's 'Set...' menu.",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 15.0, 40.0, 680.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-3",
+					"maxclass" : "inlet",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 30.0, 85.0, 30.0, 30.0 ],
+					"comment" : "slot trigger: int 1-4 play, 0 stop all"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-4",
+					"maxclass" : "comment",
+					"text" : "slot (1-4 play, 0 stop all)",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 65.0, 91.0, 200.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-5",
+					"maxclass" : "newobj",
+					"text" : "select 0 1 2 3 4",
+					"numinlets" : 1,
+					"numoutlets" : 6,
+					"outlettype" : [ "bang", "bang", "bang", "bang", "bang", "" ],
+					"patching_rect" : [ 30.0, 135.0, 150.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-6",
+					"maxclass" : "comment",
+					"text" : "outlet 0=stop-all  outlets 1-4=play slots  outlet 5=unmatched",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 195.0, 139.0, 450.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-7",
+					"maxclass" : "comment",
+					"text" : "── Slot 1 ──",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 176.0, 100.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-8",
+					"maxclass" : "comment",
+					"text" : "── Slot 2 ──",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 210.0, 176.0, 100.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-9",
+					"maxclass" : "comment",
+					"text" : "── Slot 3 ──",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 390.0, 176.0, 100.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-10",
+					"maxclass" : "comment",
+					"text" : "── Slot 4 ──",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 570.0, 176.0, 100.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-11",
+					"maxclass" : "newobj",
+					"text" : "sfplay~ 2",
+					"numinlets" : 3,
+					"numoutlets" : 3,
+					"outlettype" : [ "signal", "signal", "bang" ],
+					"patching_rect" : [ 30.0, 200.0, 90.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-12",
+					"maxclass" : "newobj",
+					"text" : "sfplay~ 2",
+					"numinlets" : 3,
+					"numoutlets" : 3,
+					"outlettype" : [ "signal", "signal", "bang" ],
+					"patching_rect" : [ 210.0, 200.0, 90.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-13",
+					"maxclass" : "newobj",
+					"text" : "sfplay~ 2",
+					"numinlets" : 3,
+					"numoutlets" : 3,
+					"outlettype" : [ "signal", "signal", "bang" ],
+					"patching_rect" : [ 390.0, 200.0, 90.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-14",
+					"maxclass" : "newobj",
+					"text" : "sfplay~ 2",
+					"numinlets" : 3,
+					"numoutlets" : 3,
+					"outlettype" : [ "signal", "signal", "bang" ],
+					"patching_rect" : [ 570.0, 200.0, 90.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-15",
+					"maxclass" : "comment",
+					"text" : "sfplay~ 2 = stereo playback\nDouble-click → Set... to load audio file",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 228.0, 240.0, 36.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-16",
+					"maxclass" : "newobj",
+					"text" : "message stop",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 30.0, 295.0, 90.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-17",
+					"maxclass" : "comment",
+					"text" : "stop-all message",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 130.0, 299.0, 130.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-18",
+					"maxclass" : "comment",
+					"text" : "── Mix ──",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 365.0, 80.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-19",
+					"maxclass" : "newobj",
+					"text" : "+~",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 30.0, 390.0, 45.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-20",
+					"maxclass" : "newobj",
+					"text" : "+~",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 90.0, 390.0, 45.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-21",
+					"maxclass" : "newobj",
+					"text" : "+~",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 150.0, 390.0, 45.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-22",
+					"maxclass" : "newobj",
+					"text" : "+~",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 30.0, 435.0, 45.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-23",
+					"maxclass" : "newobj",
+					"text" : "+~",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 90.0, 435.0, 45.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-24",
+					"maxclass" : "newobj",
+					"text" : "+~",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 150.0, 435.0, 45.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-25",
+					"maxclass" : "comment",
+					"text" : "L channels summed",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 210.0, 439.0, 150.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-26",
+					"maxclass" : "comment",
+					"text" : "R channels summed",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 210.0, 394.0, 150.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-27",
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 505.0, 30.0, 30.0 ],
+					"comment" : "audio L mix"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-28",
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 180.0, 505.0, 30.0, 30.0 ],
+					"comment" : "audio R mix"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-29",
+					"maxclass" : "comment",
+					"text" : "audio L",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 65.0, 511.0, 80.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-30",
+					"maxclass" : "comment",
+					"text" : "audio R",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 215.0, 511.0, 80.0, 18.0 ]
+				}
+			}
+		],
+		"lines" : [
+			{
+				"patchline" : 				{
+					"source" : [ "obj-3", 0 ],
+					"destination" : [ "obj-5", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-5", 0 ],
+					"destination" : [ "obj-16", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-5", 1 ],
+					"destination" : [ "obj-11", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-5", 2 ],
+					"destination" : [ "obj-12", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-5", 3 ],
+					"destination" : [ "obj-13", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-5", 4 ],
+					"destination" : [ "obj-14", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-16", 0 ],
+					"destination" : [ "obj-11", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-16", 0 ],
+					"destination" : [ "obj-12", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-16", 0 ],
+					"destination" : [ "obj-13", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-16", 0 ],
+					"destination" : [ "obj-14", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-11", 0 ],
+					"destination" : [ "obj-19", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-12", 0 ],
+					"destination" : [ "obj-19", 1 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-19", 0 ],
+					"destination" : [ "obj-21", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-13", 0 ],
+					"destination" : [ "obj-20", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-14", 0 ],
+					"destination" : [ "obj-20", 1 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-20", 0 ],
+					"destination" : [ "obj-21", 1 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-11", 1 ],
+					"destination" : [ "obj-22", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-12", 1 ],
+					"destination" : [ "obj-22", 1 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-22", 0 ],
+					"destination" : [ "obj-24", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-13", 1 ],
+					"destination" : [ "obj-23", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-14", 1 ],
+					"destination" : [ "obj-23", 1 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-23", 0 ],
+					"destination" : [ "obj-24", 1 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-21", 0 ],
+					"destination" : [ "obj-27", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-24", 0 ],
+					"destination" : [ "obj-28", 0 ],
+					"midpoints" : []
+				}
+			}
+		],
+		"parameters" : {},
+		"dependency_cache" : [],
+		"autosave" : 0
+	}
+}

--- a/ShowControl/PlayingThePipes/Music/pp.fog-led.maxpat
+++ b/ShowControl/PlayingThePipes/Music/pp.fog-led.maxpat
@@ -1,0 +1,379 @@
+{
+	"patcher" : 	{
+		"fileversion" : 1,
+		"appversion" : 		{
+			"major" : 8,
+			"minor" : 6,
+			"revision" : 2,
+			"architecture" : "x64",
+			"modernui" : 1
+		},
+		"classnamespace" : "dsp.toplevel",
+		"rect" : [ 100, 100, 700, 580 ],
+		"bglocked" : 0,
+		"openinpresentation" : 0,
+		"default_fontsize" : 12.0,
+		"default_fontface" : 0,
+		"default_fontname" : "Arial",
+		"gridonopen" : 1,
+		"gridsize" : [ 15.0, 15.0 ],
+		"gridsnaponopen" : 1,
+		"objectsnaptoobjects" : 0,
+		"statusbarvisible" : 2,
+		"toolbarvisible" : 1,
+		"description" : "Fog machine and LED control stubs. Inlet 0: fog trigger (bang or 1/0). Inlet 1: LED intensity (0.0-1.0 from encoder). Fog sends OSC via UDP; LED sends MIDI CC. Update IPs and channels to match hardware.",
+		"boxes" : [
+			{
+				"box" : 				{
+					"id" : "obj-1",
+					"maxclass" : "comment",
+					"text" : "pp.fog-led — Fog Machine & LED Control (Stub)",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 15.0, 15.0, 500.0, 22.0 ],
+					"fontsize" : 14.0,
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-2",
+					"maxclass" : "comment",
+					"text" : "Fog: OSC /pp/fog/on|off → UDP target. LED: MIDI CC 1 ch.1 → MIDI out. Update addresses to match hardware.",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 15.0, 40.0, 680.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-3",
+					"maxclass" : "inlet",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 30.0, 85.0, 30.0, 30.0 ],
+					"comment" : "fog trigger (bang, or 1=on / 0=off)"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-4",
+					"maxclass" : "inlet",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 400.0, 85.0, 30.0, 30.0 ],
+					"comment" : "LED intensity (0.0-1.0)"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-5",
+					"maxclass" : "comment",
+					"text" : "fog trigger",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 65.0, 91.0, 100.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-6",
+					"maxclass" : "comment",
+					"text" : "LED intensity (0.0-1.0)",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 435.0, 91.0, 180.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-7",
+					"maxclass" : "comment",
+					"text" : "── Fog Machine ──",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 135.0, 160.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-8",
+					"maxclass" : "newobj",
+					"text" : "select 0 1",
+					"numinlets" : 1,
+					"numoutlets" : 3,
+					"outlettype" : [ "bang", "bang", "" ],
+					"patching_rect" : [ 30.0, 157.0, 90.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-9",
+					"maxclass" : "comment",
+					"text" : "or send a bang → outlet 1 (treated as on)",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 130.0, 161.0, 300.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-10",
+					"maxclass" : "newobj",
+					"text" : "message /pp/fog/off",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 30.0, 200.0, 165.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-11",
+					"maxclass" : "newobj",
+					"text" : "message /pp/fog/on",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 210.0, 200.0, 165.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-12",
+					"maxclass" : "newobj",
+					"text" : "oscformat",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 30.0, 245.0, 90.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-13",
+					"maxclass" : "newobj",
+					"text" : "oscformat",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 210.0, 245.0, 90.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-14",
+					"maxclass" : "newobj",
+					"text" : "udpsend 192.168.1.100 9002",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 290.0, 210.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-15",
+					"maxclass" : "comment",
+					"text" : "update IP + port to match fog controller",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 250.0, 294.0, 300.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-16",
+					"maxclass" : "comment",
+					"text" : "── LEDs ──",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 400.0, 135.0, 100.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-17",
+					"maxclass" : "newobj",
+					"text" : "* 127.",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "float" ],
+					"patching_rect" : [ 400.0, 157.0, 60.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-18",
+					"maxclass" : "newobj",
+					"text" : "int",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "int" ],
+					"patching_rect" : [ 400.0, 200.0, 45.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-19",
+					"maxclass" : "comment",
+					"text" : "scale 0.0-1.0 → 0-127 for MIDI CC",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 460.0, 161.0, 250.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-20",
+					"maxclass" : "newobj",
+					"text" : "ctlout 1 1",
+					"numinlets" : 3,
+					"numoutlets" : 0,
+					"patching_rect" : [ 400.0, 245.0, 90.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-21",
+					"maxclass" : "comment",
+					"text" : "MIDI CC#1 on channel 1 → LED driver",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 500.0, 249.0, 280.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-22",
+					"maxclass" : "comment",
+					"text" : "ctlout ccnum channel — update to match LED hardware",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 400.0, 270.0, 340.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-23",
+					"maxclass" : "comment",
+					"text" : "── Timing Safety ──",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 340.0, 160.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-24",
+					"maxclass" : "newobj",
+					"text" : "timer",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "float" ],
+					"patching_rect" : [ 30.0, 362.0, 60.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-25",
+					"maxclass" : "newobj",
+					"text" : "> 500",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "int" ],
+					"patching_rect" : [ 100.0, 362.0, 60.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-26",
+					"maxclass" : "comment",
+					"text" : "Prevents re-triggering fog faster than 500ms. Connect fog on/off to timer inlets if needed.",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 170.0, 366.0, 480.0, 18.0 ]
+				}
+			}
+		],
+		"lines" : [
+			{
+				"patchline" : 				{
+					"source" : [ "obj-3", 0 ],
+					"destination" : [ "obj-8", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-8", 0 ],
+					"destination" : [ "obj-10", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-8", 1 ],
+					"destination" : [ "obj-11", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-10", 0 ],
+					"destination" : [ "obj-12", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-11", 0 ],
+					"destination" : [ "obj-13", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-12", 0 ],
+					"destination" : [ "obj-14", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-13", 0 ],
+					"destination" : [ "obj-14", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-4", 0 ],
+					"destination" : [ "obj-17", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-17", 0 ],
+					"destination" : [ "obj-18", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-18", 0 ],
+					"destination" : [ "obj-20", 0 ],
+					"midpoints" : []
+				}
+			}
+		],
+		"parameters" : {},
+		"dependency_cache" : [],
+		"autosave" : 0
+	}
+}

--- a/ShowControl/PlayingThePipes/Music/pp.fx-chain.maxpat
+++ b/ShowControl/PlayingThePipes/Music/pp.fx-chain.maxpat
@@ -1,0 +1,490 @@
+{
+	"patcher" : 	{
+		"fileversion" : 1,
+		"appversion" : 		{
+			"major" : 8,
+			"minor" : 6,
+			"revision" : 2,
+			"architecture" : "x64",
+			"modernui" : 1
+		},
+		"classnamespace" : "dsp.toplevel",
+		"rect" : [ 100, 100, 680, 680 ],
+		"bglocked" : 0,
+		"openinpresentation" : 0,
+		"default_fontsize" : 12.0,
+		"default_fontface" : 0,
+		"default_fontname" : "Arial",
+		"gridonopen" : 1,
+		"gridsize" : [ 15.0, 15.0 ],
+		"gridsnaponopen" : 1,
+		"objectsnaptoobjects" : 0,
+		"statusbarvisible" : 2,
+		"toolbarvisible" : 1,
+		"description" : "Stereo audio effects chain stub: gain -> high-pass filter -> reverb (freeverb~) -> delay (tapin~/tapout~). Inlets: L/R audio. Outlets: L/R audio.",
+		"boxes" : [
+			{
+				"box" : 				{
+					"id" : "obj-1",
+					"maxclass" : "comment",
+					"text" : "pp.fx-chain — Track Effects Chain (Stub)",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 15.0, 15.0, 420.0, 22.0 ],
+					"fontsize" : 14.0,
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-2",
+					"maxclass" : "comment",
+					"text" : "Signal path: gain~ → hip~ (HPF) → freeverb~ (reverb) → tapin~/tapout~ (delay).",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 15.0, 40.0, 630.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-3",
+					"maxclass" : "comment",
+					"text" : "Replace hip~ with biquad~ or cascade~ for a full parametric EQ.",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 15.0, 60.0, 580.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-4",
+					"maxclass" : "inlet",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 30.0, 100.0, 30.0, 30.0 ],
+					"comment" : "audio in L"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-5",
+					"maxclass" : "inlet",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 180.0, 100.0, 30.0, 30.0 ],
+					"comment" : "audio in R"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-6",
+					"maxclass" : "comment",
+					"text" : "audio in L",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 65.0, 107.0, 80.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-7",
+					"maxclass" : "comment",
+					"text" : "audio in R",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 215.0, 107.0, 80.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-8",
+					"maxclass" : "comment",
+					"text" : "── Gain ──",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 152.0, 100.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-9",
+					"maxclass" : "newobj",
+					"text" : "gain~ 2",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 30.0, 175.0, 60.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-10",
+					"maxclass" : "newobj",
+					"text" : "gain~ 2",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 180.0, 175.0, 60.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-11",
+					"maxclass" : "comment",
+					"text" : "gain~ 2 = 2-inlet variant (audio + gain factor)",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 255.0, 179.0, 340.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-12",
+					"maxclass" : "comment",
+					"text" : "── High-Pass Filter (DC block / rumble cut) ──",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 215.0, 360.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-13",
+					"maxclass" : "newobj",
+					"text" : "hip~ 40",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 30.0, 238.0, 75.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-14",
+					"maxclass" : "newobj",
+					"text" : "hip~ 40",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 180.0, 238.0, 75.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-15",
+					"maxclass" : "comment",
+					"text" : "40 Hz HPF — swap for biquad~ for full EQ",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 270.0, 242.0, 320.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-16",
+					"maxclass" : "comment",
+					"text" : "── Reverb ──",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 278.0, 100.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-17",
+					"maxclass" : "newobj",
+					"text" : "freeverb~",
+					"numinlets" : 4,
+					"numoutlets" : 2,
+					"outlettype" : [ "signal", "signal" ],
+					"patching_rect" : [ 30.0, 300.0, 90.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-18",
+					"maxclass" : "comment",
+					"text" : "freeverb~ inlets: L, R, room-size(0-1), damping(0-1)",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 130.0, 304.0, 430.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-19",
+					"maxclass" : "newobj",
+					"text" : "flonum",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "float" ],
+					"patching_rect" : [ 30.0, 330.0, 60.0, 22.0 ],
+					"parameter_enable" : 1,
+					"saved_attribute_attributes" : 				{
+						"valueof" : 					{
+							"parameter_initial" : [ 0.5 ],
+							"parameter_initial_enable" : 1,
+							"parameter_longname" : "room_size",
+							"parameter_shortname" : "room",
+							"parameter_type" : 0
+						}
+					}
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-20",
+					"maxclass" : "newobj",
+					"text" : "flonum",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "float" ],
+					"patching_rect" : [ 100.0, 330.0, 60.0, 22.0 ],
+					"parameter_enable" : 1,
+					"saved_attribute_attributes" : 				{
+						"valueof" : 					{
+							"parameter_initial" : [ 0.5 ],
+							"parameter_initial_enable" : 1,
+							"parameter_longname" : "damping",
+							"parameter_shortname" : "damp",
+							"parameter_type" : 0
+						}
+					}
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-21",
+					"maxclass" : "comment",
+					"text" : "room size",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 355.0, 75.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-22",
+					"maxclass" : "comment",
+					"text" : "damping",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 100.0, 355.0, 75.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-23",
+					"maxclass" : "comment",
+					"text" : "── Delay ──",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 385.0, 100.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-24",
+					"maxclass" : "newobj",
+					"text" : "tapin~ 1000",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "tapconnect" ],
+					"patching_rect" : [ 30.0, 407.0, 105.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-25",
+					"maxclass" : "newobj",
+					"text" : "tapin~ 1000",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "tapconnect" ],
+					"patching_rect" : [ 180.0, 407.0, 105.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-26",
+					"maxclass" : "newobj",
+					"text" : "tapout~ 250.",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 30.0, 452.0, 100.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-27",
+					"maxclass" : "newobj",
+					"text" : "tapout~ 250.",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 180.0, 452.0, 100.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-28",
+					"maxclass" : "comment",
+					"text" : "1000ms buffer, 250ms delay tap",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 295.0, 430.0, 250.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-29",
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 530.0, 30.0, 30.0 ],
+					"comment" : "audio out L"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-30",
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 180.0, 530.0, 30.0, 30.0 ],
+					"comment" : "audio out R"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-31",
+					"maxclass" : "comment",
+					"text" : "audio out L",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 65.0, 537.0, 90.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-32",
+					"maxclass" : "comment",
+					"text" : "audio out R",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 215.0, 537.0, 90.0, 18.0 ]
+				}
+			}
+		],
+		"lines" : [
+			{
+				"patchline" : 				{
+					"source" : [ "obj-4", 0 ],
+					"destination" : [ "obj-9", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-5", 0 ],
+					"destination" : [ "obj-10", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-9", 0 ],
+					"destination" : [ "obj-13", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-10", 0 ],
+					"destination" : [ "obj-14", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-13", 0 ],
+					"destination" : [ "obj-17", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-14", 0 ],
+					"destination" : [ "obj-17", 1 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-19", 0 ],
+					"destination" : [ "obj-17", 2 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-20", 0 ],
+					"destination" : [ "obj-17", 3 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-17", 0 ],
+					"destination" : [ "obj-24", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-17", 1 ],
+					"destination" : [ "obj-25", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-24", 0 ],
+					"destination" : [ "obj-26", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-25", 0 ],
+					"destination" : [ "obj-27", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-26", 0 ],
+					"destination" : [ "obj-29", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-27", 0 ],
+					"destination" : [ "obj-30", 0 ],
+					"midpoints" : []
+				}
+			}
+		],
+		"parameters" : {},
+		"dependency_cache" : [],
+		"autosave" : 0
+	}
+}

--- a/ShowControl/PlayingThePipes/Music/pp.midi-clip-launcher.maxpat
+++ b/ShowControl/PlayingThePipes/Music/pp.midi-clip-launcher.maxpat
@@ -1,0 +1,459 @@
+{
+	"patcher" : 	{
+		"fileversion" : 1,
+		"appversion" : 		{
+			"major" : 8,
+			"minor" : 6,
+			"revision" : 2,
+			"architecture" : "x64",
+			"modernui" : 1
+		},
+		"classnamespace" : "dsp.toplevel",
+		"rect" : [ 100, 100, 720, 600 ],
+		"bglocked" : 0,
+		"openinpresentation" : 0,
+		"default_fontsize" : 12.0,
+		"default_fontface" : 0,
+		"default_fontname" : "Arial",
+		"gridonopen" : 1,
+		"gridsize" : [ 15.0, 15.0 ],
+		"gridsnaponopen" : 1,
+		"objectsnaptoobjects" : 0,
+		"statusbarvisible" : 2,
+		"toolbarvisible" : 1,
+		"description" : "4-slot MIDI clip launcher. Inlet 0: slot trigger (int 1-4 play, 0 stop all). Outlet 0: MIDI pitch, Outlet 1: velocity (0=note-off), Outlet 2: gate (1=on, 0=off). Stub slots use makenote — replace with seq or mtr for real sequences.",
+		"boxes" : [
+			{
+				"box" : 				{
+					"id" : "obj-1",
+					"maxclass" : "comment",
+					"text" : "pp.midi-clip-launcher — 4-Slot MIDI Clip Launcher",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 15.0, 15.0, 500.0, 22.0 ],
+					"fontsize" : 14.0,
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-2",
+					"maxclass" : "comment",
+					"text" : "STUB: each slot fires a single makenote. Replace with seq or mtr objects for real MIDI sequences.",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 15.0, 40.0, 680.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-3",
+					"maxclass" : "inlet",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 30.0, 85.0, 30.0, 30.0 ],
+					"comment" : "slot trigger: int 1-4 play, 0 stop all"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-4",
+					"maxclass" : "comment",
+					"text" : "slot (1-4 play, 0 stop all)",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 65.0, 91.0, 200.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-5",
+					"maxclass" : "newobj",
+					"text" : "select 0 1 2 3 4",
+					"numinlets" : 1,
+					"numoutlets" : 6,
+					"outlettype" : [ "bang", "bang", "bang", "bang", "bang", "" ],
+					"patching_rect" : [ 30.0, 135.0, 150.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-6",
+					"maxclass" : "comment",
+					"text" : "outlet 0=stop  1-4=play slots",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 195.0, 139.0, 250.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-7",
+					"maxclass" : "comment",
+					"text" : "── Slot 1: C4 ──",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 176.0, 130.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-8",
+					"maxclass" : "comment",
+					"text" : "── Slot 2: E4 ──",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 210.0, 176.0, 130.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-9",
+					"maxclass" : "comment",
+					"text" : "── Slot 3: G4 ──",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 390.0, 176.0, 130.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-10",
+					"maxclass" : "comment",
+					"text" : "── Slot 4: C5 ──",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 570.0, 176.0, 130.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-11",
+					"maxclass" : "newobj",
+					"text" : "makenote 60 100 1000",
+					"numinlets" : 3,
+					"numoutlets" : 2,
+					"outlettype" : [ "int", "int" ],
+					"patching_rect" : [ 30.0, 200.0, 165.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-12",
+					"maxclass" : "newobj",
+					"text" : "makenote 64 90 800",
+					"numinlets" : 3,
+					"numoutlets" : 2,
+					"outlettype" : [ "int", "int" ],
+					"patching_rect" : [ 210.0, 200.0, 165.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-13",
+					"maxclass" : "newobj",
+					"text" : "makenote 67 80 600",
+					"numinlets" : 3,
+					"numoutlets" : 2,
+					"outlettype" : [ "int", "int" ],
+					"patching_rect" : [ 390.0, 200.0, 165.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-14",
+					"maxclass" : "newobj",
+					"text" : "makenote 72 100 400",
+					"numinlets" : 3,
+					"numoutlets" : 2,
+					"outlettype" : [ "int", "int" ],
+					"patching_rect" : [ 570.0, 200.0, 165.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-15",
+					"maxclass" : "comment",
+					"text" : "makenote pitch vel dur(ms)\nReplace with seq for real clip playback",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 230.0, 240.0, 36.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-16",
+					"maxclass" : "comment",
+					"text" : "── Merge pitch + velocity ──",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 298.0, 220.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-17",
+					"maxclass" : "newobj",
+					"text" : "funnel 4",
+					"numinlets" : 4,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 30.0, 320.0, 75.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-18",
+					"maxclass" : "newobj",
+					"text" : "funnel 4",
+					"numinlets" : 4,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 180.0, 320.0, 75.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-19",
+					"maxclass" : "comment",
+					"text" : "pitch from all 4 slots",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 115.0, 324.0, 160.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-20",
+					"maxclass" : "comment",
+					"text" : "velocity from all 4 slots (0 = note-off)",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 265.0, 324.0, 280.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-21",
+					"maxclass" : "comment",
+					"text" : "── Derive gate from velocity ──",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 370.0, 240.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-22",
+					"maxclass" : "newobj",
+					"text" : "> 0",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "int" ],
+					"patching_rect" : [ 180.0, 392.0, 45.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-23",
+					"maxclass" : "comment",
+					"text" : "1 when note-on, 0 when note-off",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 235.0, 396.0, 250.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-24",
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 460.0, 30.0, 30.0 ],
+					"comment" : "MIDI pitch"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-25",
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 180.0, 460.0, 30.0, 30.0 ],
+					"comment" : "velocity (0=note-off)"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-26",
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 330.0, 460.0, 30.0, 30.0 ],
+					"comment" : "gate (1=on, 0=off)"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-27",
+					"maxclass" : "comment",
+					"text" : "pitch",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 65.0, 466.0, 60.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-28",
+					"maxclass" : "comment",
+					"text" : "velocity",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 215.0, 466.0, 60.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-29",
+					"maxclass" : "comment",
+					"text" : "gate",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 365.0, 466.0, 60.0, 18.0 ]
+				}
+			}
+		],
+		"lines" : [
+			{
+				"patchline" : 				{
+					"source" : [ "obj-3", 0 ],
+					"destination" : [ "obj-5", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-5", 1 ],
+					"destination" : [ "obj-11", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-5", 2 ],
+					"destination" : [ "obj-12", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-5", 3 ],
+					"destination" : [ "obj-13", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-5", 4 ],
+					"destination" : [ "obj-14", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-11", 0 ],
+					"destination" : [ "obj-17", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-12", 0 ],
+					"destination" : [ "obj-17", 1 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-13", 0 ],
+					"destination" : [ "obj-17", 2 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-14", 0 ],
+					"destination" : [ "obj-17", 3 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-11", 1 ],
+					"destination" : [ "obj-18", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-12", 1 ],
+					"destination" : [ "obj-18", 1 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-13", 1 ],
+					"destination" : [ "obj-18", 2 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-14", 1 ],
+					"destination" : [ "obj-18", 3 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-18", 0 ],
+					"destination" : [ "obj-22", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-17", 0 ],
+					"destination" : [ "obj-24", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-18", 0 ],
+					"destination" : [ "obj-25", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-22", 0 ],
+					"destination" : [ "obj-26", 0 ],
+					"midpoints" : []
+				}
+			}
+		],
+		"parameters" : {},
+		"dependency_cache" : [],
+		"autosave" : 0
+	}
+}

--- a/ShowControl/PlayingThePipes/Music/pp.osc-in.maxpat
+++ b/ShowControl/PlayingThePipes/Music/pp.osc-in.maxpat
@@ -1,0 +1,345 @@
+{
+	"patcher" : 	{
+		"fileversion" : 1,
+		"appversion" : 		{
+			"major" : 8,
+			"minor" : 6,
+			"revision" : 2,
+			"architecture" : "x64",
+			"modernui" : 1
+		},
+		"classnamespace" : "dsp.toplevel",
+		"rect" : [ 100, 100, 640, 500 ],
+		"bglocked" : 0,
+		"openinpresentation" : 0,
+		"default_fontsize" : 12.0,
+		"default_fontface" : 0,
+		"default_fontname" : "Arial",
+		"gridonopen" : 1,
+		"gridsize" : [ 15.0, 15.0 ],
+		"gridsnaponopen" : 1,
+		"objectsnaptoobjects" : 0,
+		"statusbarvisible" : 2,
+		"toolbarvisible" : 1,
+		"description" : "OSC input handler. Listens on UDP port 9001. Routes /pp/encoder and /pp/switch messages. Outlet 0: encoder data [num val]. Outlet 1: switch data [num val].",
+		"boxes" : [
+			{
+				"box" : 				{
+					"id" : "obj-1",
+					"maxclass" : "comment",
+					"text" : "pp.osc-in — OSC Input Handler",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 15.0, 15.0, 400.0, 22.0 ],
+					"fontsize" : 14.0,
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-2",
+					"maxclass" : "comment",
+					"text" : "Receives OSC over UDP on port 9001. No inlets — self-contained receiver.",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 15.0, 40.0, 560.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-3",
+					"maxclass" : "comment",
+					"text" : "Expected OSC address format:",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 15.0, 63.0, 220.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-4",
+					"maxclass" : "comment",
+					"text" : "  /pp/encoder [1-8] [0.0-1.0]    — continuous rotary encoder (water valve)",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 15.0, 81.0, 500.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-5",
+					"maxclass" : "comment",
+					"text" : "  /pp/switch  [1-8] [0 or 1]     — momentary electrical switch",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 15.0, 99.0, 500.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-6",
+					"maxclass" : "newobj",
+					"text" : "udpreceive 9001",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 30.0, 135.0, 135.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-7",
+					"maxclass" : "comment",
+					"text" : "listen on UDP port 9001",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 175.0, 139.0, 200.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-8",
+					"maxclass" : "newobj",
+					"text" : "oscparse",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 30.0, 180.0, 75.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-9",
+					"maxclass" : "comment",
+					"text" : "parse OSC bundle → address + args list",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 115.0, 184.0, 280.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-10",
+					"maxclass" : "newobj",
+					"text" : "route /pp/encoder /pp/switch",
+					"numinlets" : 1,
+					"numoutlets" : 3,
+					"outlettype" : [ "", "", "" ],
+					"patching_rect" : [ 30.0, 225.0, 240.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-11",
+					"maxclass" : "comment",
+					"text" : "outlet 2 = unmatched (ignore or log)",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 280.0, 229.0, 280.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-12",
+					"maxclass" : "comment",
+					"text" : "── Encoders ──",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 268.0, 130.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-13",
+					"maxclass" : "comment",
+					"text" : "── Switches ──",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 340.0, 268.0, 130.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-14",
+					"maxclass" : "newobj",
+					"text" : "unpack i f",
+					"numinlets" : 1,
+					"numoutlets" : 2,
+					"outlettype" : [ "int", "float" ],
+					"patching_rect" : [ 30.0, 290.0, 90.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-15",
+					"maxclass" : "comment",
+					"text" : "encoder num (1-8), value (0.0-1.0)",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 130.0, 294.0, 260.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-16",
+					"maxclass" : "newobj",
+					"text" : "unpack i i",
+					"numinlets" : 1,
+					"numoutlets" : 2,
+					"outlettype" : [ "int", "int" ],
+					"patching_rect" : [ 340.0, 290.0, 90.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-17",
+					"maxclass" : "comment",
+					"text" : "switch num (1-8), state (0 or 1)",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 440.0, 294.0, 260.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-18",
+					"maxclass" : "newobj",
+					"text" : "pack i f",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 30.0, 340.0, 75.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-19",
+					"maxclass" : "newobj",
+					"text" : "pack i i",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 340.0, 340.0, 75.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-20",
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 400.0, 30.0, 30.0 ],
+					"comment" : "encoder data: list [num val]"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-21",
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 340.0, 400.0, 30.0, 30.0 ],
+					"comment" : "switch data: list [num state]"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-22",
+					"maxclass" : "comment",
+					"text" : "encoder [num val]",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 65.0, 407.0, 150.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-23",
+					"maxclass" : "comment",
+					"text" : "switch [num state]",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 375.0, 407.0, 150.0, 18.0 ]
+				}
+			}
+		],
+		"lines" : [
+			{
+				"patchline" : 				{
+					"source" : [ "obj-6", 0 ],
+					"destination" : [ "obj-8", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-8", 0 ],
+					"destination" : [ "obj-10", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-10", 0 ],
+					"destination" : [ "obj-14", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-10", 1 ],
+					"destination" : [ "obj-16", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-14", 0 ],
+					"destination" : [ "obj-18", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-14", 1 ],
+					"destination" : [ "obj-18", 1 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-16", 0 ],
+					"destination" : [ "obj-19", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-16", 1 ],
+					"destination" : [ "obj-19", 1 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-18", 0 ],
+					"destination" : [ "obj-20", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-19", 0 ],
+					"destination" : [ "obj-21", 0 ],
+					"midpoints" : []
+				}
+			}
+		],
+		"parameters" : {},
+		"dependency_cache" : [],
+		"autosave" : 0
+	}
+}

--- a/ShowControl/PlayingThePipes/Music/pp.spatial-out.maxpat
+++ b/ShowControl/PlayingThePipes/Music/pp.spatial-out.maxpat
@@ -1,0 +1,442 @@
+{
+	"patcher" : 	{
+		"fileversion" : 1,
+		"appversion" : 		{
+			"major" : 8,
+			"minor" : 6,
+			"revision" : 2,
+			"architecture" : "x64",
+			"modernui" : 1
+		},
+		"classnamespace" : "dsp.toplevel",
+		"rect" : [ 100, 100, 720, 620 ],
+		"bglocked" : 0,
+		"openinpresentation" : 0,
+		"default_fontsize" : 12.0,
+		"default_fontface" : 0,
+		"default_fontname" : "Arial",
+		"gridonopen" : 1,
+		"gridsize" : [ 15.0, 15.0 ],
+		"gridsnaponopen" : 1,
+		"objectsnaptoobjects" : 0,
+		"statusbarvisible" : 2,
+		"toolbarvisible" : 1,
+		"description" : "4-channel spatial output stub. Inlets: L bus, R bus (stereo mix). Outlets: Ch1 front-L, Ch2 front-R, Ch3 rear-L, Ch4 rear-R. Stub distributes L->Ch1+Ch3, R->Ch2+Ch4 with rear attenuation. Replace *~ scalars with a proper panning matrix or spatialization library.",
+		"boxes" : [
+			{
+				"box" : 				{
+					"id" : "obj-1",
+					"maxclass" : "comment",
+					"text" : "pp.spatial-out — 4-Channel Spatial Output (Stub)",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 15.0, 15.0, 480.0, 22.0 ],
+					"fontsize" : 14.0,
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-2",
+					"maxclass" : "comment",
+					"text" : "STUB: L→Ch1(front-L)+Ch3(rear-L), R→Ch2(front-R)+Ch4(rear-R). Rear channels attenuated by 0.5.",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 15.0, 40.0, 680.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-3",
+					"maxclass" : "comment",
+					"text" : "Replace scalar *~ with a proper pan matrix or IRCAM Spat / ICST Ambisonics for real spatialization.",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 15.0, 60.0, 680.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-4",
+					"maxclass" : "inlet",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 30.0, 100.0, 30.0, 30.0 ],
+					"comment" : "L mix bus"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-5",
+					"maxclass" : "inlet",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 300.0, 100.0, 30.0, 30.0 ],
+					"comment" : "R mix bus"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-6",
+					"maxclass" : "comment",
+					"text" : "L mix bus",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 65.0, 107.0, 80.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-7",
+					"maxclass" : "comment",
+					"text" : "R mix bus",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 335.0, 107.0, 80.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-8",
+					"maxclass" : "comment",
+					"text" : "── Front Channels ──",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 155.0, 180.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-9",
+					"maxclass" : "newobj",
+					"text" : "*~ 0.7",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 30.0, 178.0, 60.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-10",
+					"maxclass" : "newobj",
+					"text" : "*~ 0.7",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 300.0, 178.0, 60.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-11",
+					"maxclass" : "comment",
+					"text" : "Ch1: front-L (-3 dB)",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 100.0, 182.0, 150.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-12",
+					"maxclass" : "comment",
+					"text" : "Ch2: front-R (-3 dB)",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 370.0, 182.0, 150.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-13",
+					"maxclass" : "comment",
+					"text" : "── Rear Channels ──",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 225.0, 180.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-14",
+					"maxclass" : "newobj",
+					"text" : "*~ 0.5",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 30.0, 248.0, 60.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-15",
+					"maxclass" : "newobj",
+					"text" : "*~ 0.5",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 300.0, 248.0, 60.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-16",
+					"maxclass" : "comment",
+					"text" : "Ch3: rear-L (-6 dB, attenuated stub)",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 100.0, 252.0, 260.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-17",
+					"maxclass" : "comment",
+					"text" : "Ch4: rear-R (-6 dB, attenuated stub)",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 370.0, 252.0, 260.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-18",
+					"maxclass" : "comment",
+					"text" : "── Master Limiter ──",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 298.0, 180.0, 18.0 ],
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-19",
+					"maxclass" : "newobj",
+					"text" : "clip~ -1. 1.",
+					"numinlets" : 3,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 30.0, 320.0, 90.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-20",
+					"maxclass" : "newobj",
+					"text" : "clip~ -1. 1.",
+					"numinlets" : 3,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 160.0, 320.0, 90.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-21",
+					"maxclass" : "newobj",
+					"text" : "clip~ -1. 1.",
+					"numinlets" : 3,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 290.0, 320.0, 90.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-22",
+					"maxclass" : "newobj",
+					"text" : "clip~ -1. 1.",
+					"numinlets" : 3,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 420.0, 320.0, 90.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-23",
+					"maxclass" : "comment",
+					"text" : "hard clip at ±1.0 — replace with a proper brickwall limiter",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 348.0, 400.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-24",
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 430.0, 30.0, 30.0 ],
+					"comment" : "Ch1: front-L"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-25",
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 160.0, 430.0, 30.0, 30.0 ],
+					"comment" : "Ch2: front-R"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-26",
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 290.0, 430.0, 30.0, 30.0 ],
+					"comment" : "Ch3: rear-L"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-27",
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 420.0, 430.0, 30.0, 30.0 ],
+					"comment" : "Ch4: rear-R"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-28",
+					"maxclass" : "comment",
+					"text" : "Ch1 front-L",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 65.0, 437.0, 90.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-29",
+					"maxclass" : "comment",
+					"text" : "Ch2 front-R",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 195.0, 437.0, 90.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-30",
+					"maxclass" : "comment",
+					"text" : "Ch3 rear-L",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 325.0, 437.0, 90.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-31",
+					"maxclass" : "comment",
+					"text" : "Ch4 rear-R",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 455.0, 437.0, 90.0, 18.0 ]
+				}
+			}
+		],
+		"lines" : [
+			{
+				"patchline" : 				{
+					"source" : [ "obj-4", 0 ],
+					"destination" : [ "obj-9", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-5", 0 ],
+					"destination" : [ "obj-10", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-4", 0 ],
+					"destination" : [ "obj-14", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-5", 0 ],
+					"destination" : [ "obj-15", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-9", 0 ],
+					"destination" : [ "obj-19", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-10", 0 ],
+					"destination" : [ "obj-20", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-14", 0 ],
+					"destination" : [ "obj-21", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-15", 0 ],
+					"destination" : [ "obj-22", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-19", 0 ],
+					"destination" : [ "obj-24", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-20", 0 ],
+					"destination" : [ "obj-25", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-21", 0 ],
+					"destination" : [ "obj-26", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-22", 0 ],
+					"destination" : [ "obj-27", 0 ],
+					"midpoints" : []
+				}
+			}
+		],
+		"parameters" : {},
+		"dependency_cache" : [],
+		"autosave" : 0
+	}
+}

--- a/ShowControl/PlayingThePipes/Music/pp.synth.maxpat
+++ b/ShowControl/PlayingThePipes/Music/pp.synth.maxpat
@@ -1,0 +1,380 @@
+{
+	"patcher" : 	{
+		"fileversion" : 1,
+		"appversion" : 		{
+			"major" : 8,
+			"minor" : 6,
+			"revision" : 2,
+			"architecture" : "x64",
+			"modernui" : 1
+		},
+		"classnamespace" : "dsp.toplevel",
+		"rect" : [ 100, 100, 500, 560 ],
+		"bglocked" : 0,
+		"openinpresentation" : 0,
+		"default_fontsize" : 12.0,
+		"default_fontface" : 0,
+		"default_fontname" : "Arial",
+		"gridonopen" : 1,
+		"gridsize" : [ 15.0, 15.0 ],
+		"gridsnaponopen" : 1,
+		"objectsnaptoobjects" : 0,
+		"statusbarvisible" : 2,
+		"toolbarvisible" : 1,
+		"description" : "Stub synthesizer voice — sine oscillator with ADSR envelope. Inlet 0: MIDI pitch (0-127). Inlet 1: velocity (0-127). Inlet 2: gate (1=attack, 0=release). Outlets: L/R audio signal.",
+		"boxes" : [
+			{
+				"box" : 				{
+					"id" : "obj-1",
+					"maxclass" : "comment",
+					"text" : "pp.synth — Stub Synthesizer Voice",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 15.0, 15.0, 400.0, 22.0 ],
+					"fontsize" : 14.0,
+					"fontface" : 1
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-2",
+					"maxclass" : "comment",
+					"text" : "Sine oscillator + ADSR envelope. Swap cycle~ for a richer source when ready.",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 15.0, 40.0, 460.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-3",
+					"maxclass" : "inlet",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 30.0, 90.0, 30.0, 30.0 ],
+					"comment" : "MIDI pitch (0-127)"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-4",
+					"maxclass" : "inlet",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 180.0, 90.0, 30.0, 30.0 ],
+					"comment" : "velocity (0-127)"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-5",
+					"maxclass" : "inlet",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 330.0, 90.0, 30.0, 30.0 ],
+					"comment" : "gate (1=attack, 0=release)"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-6",
+					"maxclass" : "comment",
+					"text" : "MIDI pitch",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 65.0, 96.0, 90.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-7",
+					"maxclass" : "comment",
+					"text" : "velocity",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 215.0, 96.0, 90.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-8",
+					"maxclass" : "comment",
+					"text" : "gate",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 365.0, 96.0, 60.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-9",
+					"maxclass" : "newobj",
+					"text" : "mtof",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "float" ],
+					"patching_rect" : [ 30.0, 145.0, 60.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-10",
+					"maxclass" : "newobj",
+					"text" : "/ 127.",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "float" ],
+					"patching_rect" : [ 180.0, 145.0, 60.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-11",
+					"maxclass" : "newobj",
+					"text" : "adsr~ 10 100 0.7 200",
+					"numinlets" : 5,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 255.0, 145.0, 185.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-12",
+					"maxclass" : "comment",
+					"text" : "attack=10ms  decay=100ms  sustain=0.7  release=200ms",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 255.0, 170.0, 320.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-13",
+					"maxclass" : "newobj",
+					"text" : "cycle~ 440",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 30.0, 200.0, 90.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-14",
+					"maxclass" : "newobj",
+					"text" : "sig~",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 180.0, 200.0, 45.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-15",
+					"maxclass" : "comment",
+					"text" : "freq via right inlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 125.0, 200.0, 130.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-16",
+					"maxclass" : "newobj",
+					"text" : "*~",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 30.0, 255.0, 45.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-17",
+					"maxclass" : "comment",
+					"text" : "osc * envelope",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 85.0, 255.0, 110.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-18",
+					"maxclass" : "newobj",
+					"text" : "*~",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 30.0, 310.0, 45.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-19",
+					"maxclass" : "comment",
+					"text" : "* velocity amplitude",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 85.0, 310.0, 150.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-20",
+					"maxclass" : "newobj",
+					"text" : "*~ 0.5",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "signal" ],
+					"patching_rect" : [ 30.0, 365.0, 60.0, 22.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-21",
+					"maxclass" : "comment",
+					"text" : "safety headroom (-6 dB)",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 100.0, 365.0, 180.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-22",
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 30.0, 425.0, 30.0, 30.0 ],
+					"comment" : "audio L"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-23",
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 180.0, 425.0, 30.0, 30.0 ],
+					"comment" : "audio R"
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-24",
+					"maxclass" : "comment",
+					"text" : "audio L",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 65.0, 431.0, 80.0, 18.0 ]
+				}
+			},
+			{
+				"box" : 				{
+					"id" : "obj-25",
+					"maxclass" : "comment",
+					"text" : "audio R",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 215.0, 431.0, 80.0, 18.0 ]
+				}
+			}
+		],
+		"lines" : [
+			{
+				"patchline" : 				{
+					"source" : [ "obj-3", 0 ],
+					"destination" : [ "obj-9", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-4", 0 ],
+					"destination" : [ "obj-10", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-5", 0 ],
+					"destination" : [ "obj-11", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-9", 0 ],
+					"destination" : [ "obj-13", 1 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-10", 0 ],
+					"destination" : [ "obj-14", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-13", 0 ],
+					"destination" : [ "obj-16", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-11", 0 ],
+					"destination" : [ "obj-16", 1 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-16", 0 ],
+					"destination" : [ "obj-18", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-14", 0 ],
+					"destination" : [ "obj-18", 1 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-18", 0 ],
+					"destination" : [ "obj-20", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-20", 0 ],
+					"destination" : [ "obj-22", 0 ],
+					"midpoints" : []
+				}
+			},
+			{
+				"patchline" : 				{
+					"source" : [ "obj-20", 0 ],
+					"destination" : [ "obj-23", 0 ],
+					"midpoints" : []
+				}
+			}
+		],
+		"parameters" : {},
+		"dependency_cache" : [],
+		"autosave" : 0
+	}
+}


### PR DESCRIPTION
## Summary

Creates `ShowControl/PlayingThePipes/Music/` with 8 Max 8 patches that stub out the complete music system architecture for the Playing The Pipes installation.

### Signal flow

```
pp.osc-in  (UDP 9001: 8 encoders + 8 switches)
    │
    ├─ switches 1-4 ──► pp.audio-clip-launcher  (4× sfplay~)
    │                           │
    ├─ switches 5-8 ──► pp.midi-clip-launcher   (4× makenote stub)
    │                           │
    │                   pp.synth × 2             (cycle~ + adsr~)
    │                           │
    └─ encoder 8 ────► pp.fog-led               (OSC fog / MIDI CC LEDs)
                                │
                       pp.fx-chain              (gain → HPF → freeverb~ → delay)
                                │
                       pp.spatial-out           (4-ch: front-L/R, rear-L/R)
                                │
                           dac~ 1 2 3 4
```

### Patches

| File | Role |
|---|---|
| `PlayingThePipes.maxpat` | Top-level orchestration |
| `pp.osc-in.maxpat` | OSC input — routes `/pp/encoder` and `/pp/switch` from UDP 9001 |
| `pp.audio-clip-launcher.maxpat` | 4-slot `sfplay~` launcher; load files via Set… menu |
| `pp.midi-clip-launcher.maxpat` | 4-slot MIDI launcher (`makenote` stubs; swap for `seq`/`mtr`) |
| `pp.synth.maxpat` | Sine oscillator + ADSR voice; swap `cycle~` for richer source |
| `pp.fx-chain.maxpat` | Gain → `hip~` → `freeverb~` → `tapin~/tapout~` |
| `pp.spatial-out.maxpat` | Stereo→4-ch distribution; replace `*~` scalars with real spatialization |
| `pp.fog-led.maxpat` | Fog via OSC/UDP; LEDs via MIDI CC (`ctlout`) |

### What's stubbed / needs finishing

- **Audio clips**: load `.aif`/`.wav` files into each `sfplay~` slot
- **MIDI sequences**: replace `makenote` with `seq` or `mtr` objects for real clips
- **Synths**: replace `cycle~` with FM/wavetable/etc.
- **Spatialization**: replace amplitude-only matrix in `pp.spatial-out` with IRCAM Spat or similar
- **Fog/LED hardware addresses**: update IP/port in `pp.fog-led` to match the actual controllers

## Test plan

- [ ] Open `PlayingThePipes.maxpat` in Max 8 — all `pp.*` abstractions should load without errors (they live in the same folder)
- [ ] Enable DSP (`cmd+/`) — no audio errors in the Max console
- [ ] Send test OSC to port 9001 and confirm messages flow through `pp.osc-in`
- [ ] Trigger slots 1-4 and confirm `pp.audio-clip-launcher` outputs (add a test `.aif`)
- [ ] Trigger slots 1-4 and confirm `pp.midi-clip-launcher` outputs pitch/velocity/gate
- [ ] Verify `pp.synth` produces audio when given pitch + gate messages

https://claude.ai/code/session_01HxMf7haGbmPwkWmHhQ5iGZ