### PR TITLE
Add TreeHouse show-control stub

### DIFF
--- a/ShowControl/TreeHouse/coordinator.py
+++ b/ShowControl/TreeHouse/coordinator.py
@@ -1,0 +1,185 @@
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from displays import (
+    Display,
+    DisplayState,
+    LEDDisplay,
+    LEDConfig,
+    LookingGlassDisplay,
+    LookingGlassConfig,
+    ForgeAndFloraDisplay,
+    ForgeAndFloraConfig,
+)
+
+log = logging.getLogger("treehouse")
+
+
+# ---------------------------------------------------------------------------
+# Config dataclasses (mirror settings.json structure)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DioramaConfig:
+    name: str
+    brightness: float = 1.0
+    color: tuple[int, int, int] = (255, 255, 255)
+    pattern: str = "solid"
+
+
+@dataclass
+class GableWindowConfig:
+    name: str
+    brightness: float = 1.0
+    color: tuple[int, int, int] = (255, 255, 255)
+    pattern: str = "solid"
+
+
+@dataclass
+class DormerConfig:
+    name: str
+    brightness: float = 1.0
+    color: tuple[int, int, int] = (255, 255, 255)
+    pattern: str = "solid"
+
+
+@dataclass
+class TreehouseConfig:
+    dioramas: list[DioramaConfig]
+    looking_glass: LookingGlassConfig
+    forge_and_flora: ForgeAndFloraConfig
+    gable_front: GableWindowConfig
+    gable_back: GableWindowConfig
+    dormer: DormerConfig
+
+
+# ---------------------------------------------------------------------------
+# Config loader
+# ---------------------------------------------------------------------------
+
+def load_config(path: str) -> TreehouseConfig:
+    with open(path) as f:
+        raw = json.load(f)
+
+    dioramas = [
+        DioramaConfig(
+            name=d["name"],
+            brightness=d.get("brightness", 1.0),
+            color=tuple(d.get("color", [255, 255, 255])),  # type: ignore[arg-type]
+            pattern=d.get("pattern", "solid"),
+        )
+        for d in raw["dioramas"]
+    ]
+
+    lg = raw["garage_windows"]["looking_glass"]
+    looking_glass = LookingGlassConfig(
+        name=lg.get("name", "Looking Glass"),
+        scene=lg.get("scene", "bloom"),
+        speed=lg.get("speed", 1.0),
+        mirror_depth=lg.get("mirror_depth", 6),
+    )
+
+    ff = raw["garage_windows"]["forge_and_flora"]
+    forge_and_flora = ForgeAndFloraConfig(
+        name=ff.get("name", "Forge & Flora"),
+        blend=ff.get("blend", 0.0),
+        transition_speed=ff.get("transition_speed", 0.1),
+        flicker_intensity=ff.get("flicker_intensity", 0.3),
+    )
+
+    gf = raw["gable_windows"]["front"]
+    gable_front = GableWindowConfig(
+        name=gf.get("name", "Front Gable"),
+        brightness=gf.get("brightness", 1.0),
+        color=tuple(gf.get("color", [255, 255, 255])),  # type: ignore[arg-type]
+        pattern=gf.get("pattern", "solid"),
+    )
+
+    gb = raw["gable_windows"]["back"]
+    gable_back = GableWindowConfig(
+        name=gb.get("name", "Back Gable"),
+        brightness=gb.get("brightness", 1.0),
+        color=tuple(gb.get("color", [255, 255, 255])),  # type: ignore[arg-type]
+        pattern=gb.get("pattern", "solid"),
+    )
+
+    dw = raw["dormer"]
+    dormer = DormerConfig(
+        name=dw.get("name", "Dormer"),
+        brightness=dw.get("brightness", 1.0),
+        color=tuple(dw.get("color", [255, 255, 255])),  # type: ignore[arg-type]
+        pattern=dw.get("pattern", "solid"),
+    )
+
+    return TreehouseConfig(
+        dioramas=dioramas,
+        looking_glass=looking_glass,
+        forge_and_flora=forge_and_flora,
+        gable_front=gable_front,
+        gable_back=gable_back,
+        dormer=dormer,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Display factory
+# ---------------------------------------------------------------------------
+
+def build_displays(config: TreehouseConfig) -> list[Display]:
+    displays: list[Display] = []
+
+    for d in config.dioramas:
+        displays.append(LEDDisplay(LEDConfig(
+            name=d.name,
+            brightness=d.brightness,
+            color=d.color,
+            pattern=d.pattern,
+        )))
+
+    displays.append(LookingGlassDisplay(config.looking_glass))
+    displays.append(ForgeAndFloraDisplay(config.forge_and_flora))
+
+    for gable in (config.gable_front, config.gable_back):
+        displays.append(LEDDisplay(LEDConfig(
+            name=gable.name,
+            brightness=gable.brightness,
+            color=gable.color,
+            pattern=gable.pattern,
+        )))
+
+    displays.append(LEDDisplay(LEDConfig(
+        name=config.dormer.name,
+        brightness=config.dormer.brightness,
+        color=config.dormer.color,
+        pattern=config.dormer.pattern,
+    )))
+
+    return displays
+
+
+# ---------------------------------------------------------------------------
+# Coordinator
+# ---------------------------------------------------------------------------
+
+class Coordinator:
+    """Owns all Display instances and drives the per-frame update loop."""
+
+    def __init__(self, displays: list[Display]) -> None:
+        self._displays: dict[str, Display] = {d.name: d for d in displays}
+
+    def get(self, name: str) -> Display:
+        """Look up a display by name."""
+        return self._displays[name]
+
+    def update(self, dt: float) -> None:
+        for display in self._displays.values():
+            display.update(dt)
+
+    def get_all_states(self) -> list[DisplayState]:
+        return [d.get_state() for d in self._displays.values()]
+
+    @property
+    def display_names(self) -> list[str]:
+        return list(self._displays.keys())

--- a/ShowControl/TreeHouse/coordinator.py
+++ b/ShowControl/TreeHouse/coordinator.py
@@ -1,52 +1,80 @@
 import json
 import logging
-from dataclasses import dataclass, field
-from typing import Any
+from dataclasses import dataclass
 
 from displays import (
+    ChannelFrame,
+    Color,
     Display,
     DisplayState,
-    LEDDisplay,
-    LEDConfig,
-    LookingGlassDisplay,
-    LookingGlassConfig,
-    ForgeAndFloraDisplay,
     ForgeAndFloraConfig,
+    ForgeAndFloraDisplay,
+    LEDConfig,
+    LEDDisplay,
+    LookingGlassConfig,
+    LookingGlassDisplay,
+    ShowMode,
 )
 
 log = logging.getLogger("treehouse")
 
 
 # ---------------------------------------------------------------------------
-# Config dataclasses (mirror settings.json structure)
+# Config dataclasses — mirror settings.json structure
 # ---------------------------------------------------------------------------
+
+@dataclass
+class PicoConfig:
+    port: str = "/dev/ttyACM0"
+    baud: int = 115200
+
+
+@dataclass
+class OSCConfig:
+    listen_port: int = 9001
+
+
+@dataclass
+class ShowConfig:
+    fps: int = 30
+    dim_level: float = 0.25
+
 
 @dataclass
 class DioramaConfig:
     name: str
+    pico_pin: int
+    led_count: int
     brightness: float = 1.0
-    color: tuple[int, int, int] = (255, 255, 255)
+    color: Color = (0, 0, 0, 255)
     pattern: str = "solid"
 
 
 @dataclass
 class GableWindowConfig:
     name: str
+    pico_pin: int
+    led_count: int
     brightness: float = 1.0
-    color: tuple[int, int, int] = (255, 255, 255)
+    color: Color = (0, 0, 0, 255)
     pattern: str = "solid"
 
 
 @dataclass
 class DormerConfig:
     name: str
+    pico_pin: int
+    led_count: int
     brightness: float = 1.0
-    color: tuple[int, int, int] = (255, 255, 255)
+    color: Color = (0, 0, 0, 255)
     pattern: str = "solid"
 
 
 @dataclass
 class TreehouseConfig:
+    pico: PicoConfig
+    osc: OSCConfig
+    show: ShowConfig
     dioramas: list[DioramaConfig]
     looking_glass: LookingGlassConfig
     forge_and_flora: ForgeAndFloraConfig
@@ -59,18 +87,30 @@ class TreehouseConfig:
 # Config loader
 # ---------------------------------------------------------------------------
 
+def _color(raw: list[int]) -> Color:
+    if len(raw) != 4:
+        raise ValueError(f"Color must be [R, G, B, W], got {raw!r}")
+    return (raw[0], raw[1], raw[2], raw[3])
+
+
 def load_config(path: str) -> TreehouseConfig:
     with open(path) as f:
         raw = json.load(f)
 
+    pico_raw = raw.get("pico", {})
+    osc_raw  = raw.get("osc", {})
+    show_raw = raw.get("show", {})
+
     dioramas = [
         DioramaConfig(
             name=d["name"],
+            pico_pin=d["pico_pin"],
+            led_count=d["led_count"],
             brightness=d.get("brightness", 1.0),
-            color=tuple(d.get("color", [255, 255, 255])),  # type: ignore[arg-type]
+            color=_color(d.get("color", [0, 0, 0, 255])),
             pattern=d.get("pattern", "solid"),
         )
-        for d in raw["dioramas"]
+        for d in raw.get("dioramas", [])
     ]
 
     lg = raw["garage_windows"]["looking_glass"]
@@ -84,6 +124,9 @@ def load_config(path: str) -> TreehouseConfig:
     ff = raw["garage_windows"]["forge_and_flora"]
     forge_and_flora = ForgeAndFloraConfig(
         name=ff.get("name", "Forge & Flora"),
+        arc_pin=ff["arc_pin"],
+        bloom_pin=ff["bloom_pin"],
+        led_count=ff.get("led_count", 48),
         blend=ff.get("blend", 0.0),
         transition_speed=ff.get("transition_speed", 0.1),
         flicker_intensity=ff.get("flicker_intensity", 0.3),
@@ -92,28 +135,45 @@ def load_config(path: str) -> TreehouseConfig:
     gf = raw["gable_windows"]["front"]
     gable_front = GableWindowConfig(
         name=gf.get("name", "Front Gable"),
+        pico_pin=gf["pico_pin"],
+        led_count=gf["led_count"],
         brightness=gf.get("brightness", 1.0),
-        color=tuple(gf.get("color", [255, 255, 255])),  # type: ignore[arg-type]
+        color=_color(gf.get("color", [0, 0, 0, 255])),
         pattern=gf.get("pattern", "solid"),
     )
 
     gb = raw["gable_windows"]["back"]
     gable_back = GableWindowConfig(
         name=gb.get("name", "Back Gable"),
+        pico_pin=gb["pico_pin"],
+        led_count=gb["led_count"],
         brightness=gb.get("brightness", 1.0),
-        color=tuple(gb.get("color", [255, 255, 255])),  # type: ignore[arg-type]
+        color=_color(gb.get("color", [0, 0, 0, 255])),
         pattern=gb.get("pattern", "solid"),
     )
 
     dw = raw["dormer"]
     dormer = DormerConfig(
         name=dw.get("name", "Dormer"),
+        pico_pin=dw["pico_pin"],
+        led_count=dw["led_count"],
         brightness=dw.get("brightness", 1.0),
-        color=tuple(dw.get("color", [255, 255, 255])),  # type: ignore[arg-type]
+        color=_color(dw.get("color", [0, 0, 0, 255])),
         pattern=dw.get("pattern", "solid"),
     )
 
     return TreehouseConfig(
+        pico=PicoConfig(
+            port=pico_raw.get("port", "/dev/ttyACM0"),
+            baud=pico_raw.get("baud", 115200),
+        ),
+        osc=OSCConfig(
+            listen_port=osc_raw.get("listen_port", 9001),
+        ),
+        show=ShowConfig(
+            fps=show_raw.get("fps", 30),
+            dim_level=show_raw.get("dim_level", 0.25),
+        ),
         dioramas=dioramas,
         looking_glass=looking_glass,
         forge_and_flora=forge_and_flora,
@@ -133,6 +193,8 @@ def build_displays(config: TreehouseConfig) -> list[Display]:
     for d in config.dioramas:
         displays.append(LEDDisplay(LEDConfig(
             name=d.name,
+            pico_pin=d.pico_pin,
+            led_count=d.led_count,
             brightness=d.brightness,
             color=d.color,
             pattern=d.pattern,
@@ -144,6 +206,8 @@ def build_displays(config: TreehouseConfig) -> list[Display]:
     for gable in (config.gable_front, config.gable_back):
         displays.append(LEDDisplay(LEDConfig(
             name=gable.name,
+            pico_pin=gable.pico_pin,
+            led_count=gable.led_count,
             brightness=gable.brightness,
             color=gable.color,
             pattern=gable.pattern,
@@ -151,6 +215,8 @@ def build_displays(config: TreehouseConfig) -> list[Display]:
 
     displays.append(LEDDisplay(LEDConfig(
         name=config.dormer.name,
+        pico_pin=config.dormer.pico_pin,
+        led_count=config.dormer.led_count,
         brightness=config.dormer.brightness,
         color=config.dormer.color,
         pattern=config.dormer.pattern,
@@ -164,18 +230,44 @@ def build_displays(config: TreehouseConfig) -> list[Display]:
 # ---------------------------------------------------------------------------
 
 class Coordinator:
-    """Owns all Display instances and drives the per-frame update loop."""
+    """Owns all Display instances, drives the frame loop, manages show state."""
 
     def __init__(self, displays: list[Display]) -> None:
         self._displays: dict[str, Display] = {d.name: d for d in displays}
+        self.mode = ShowMode.FULL
+        self._dim_level = 0.25
+
+    @property
+    def brightness(self) -> float:
+        if self.mode == ShowMode.OFF:
+            return 0.0
+        if self.mode == ShowMode.DIM:
+            return self._dim_level
+        return 1.0
+
+    def set_mode(self, mode_str: str) -> None:
+        try:
+            self.mode = ShowMode(mode_str)
+            log.info("Show mode → %s (brightness %.2f)", self.mode.value, self.brightness)
+        except ValueError:
+            log.warning("Unknown show mode %r; valid: %s", mode_str, [m.value for m in ShowMode])
+
+    def set_dim_level(self, level: float) -> None:
+        self._dim_level = max(0.0, min(1.0, level))
+        log.info("Dim level → %.2f", self._dim_level)
 
     def get(self, name: str) -> Display:
-        """Look up a display by name."""
         return self._displays[name]
 
     def update(self, dt: float) -> None:
         for display in self._displays.values():
             display.update(dt)
+
+    def get_all_frames(self) -> list[ChannelFrame]:
+        frames: list[ChannelFrame] = []
+        for display in self._displays.values():
+            frames.extend(display.get_frames())
+        return frames
 
     def get_all_states(self) -> list[DisplayState]:
         return [d.get_state() for d in self._displays.values()]

--- a/ShowControl/TreeHouse/displays/__init__.py
+++ b/ShowControl/TreeHouse/displays/__init__.py
@@ -1,11 +1,15 @@
-from .base import Display, DisplayState
+from .base import ChannelFrame, Color, Display, DisplayState, ShowMode, scale_color
 from .led import LEDDisplay, LEDConfig
 from .video import LookingGlassDisplay, LookingGlassConfig
 from .effect import ForgeAndFloraDisplay, ForgeAndFloraConfig
 
 __all__ = [
+    "ChannelFrame",
+    "Color",
     "Display",
     "DisplayState",
+    "ShowMode",
+    "scale_color",
     "LEDDisplay",
     "LEDConfig",
     "LookingGlassDisplay",

--- a/ShowControl/TreeHouse/displays/__init__.py
+++ b/ShowControl/TreeHouse/displays/__init__.py
@@ -1,0 +1,15 @@
+from .base import Display, DisplayState
+from .led import LEDDisplay, LEDConfig
+from .video import LookingGlassDisplay, LookingGlassConfig
+from .effect import ForgeAndFloraDisplay, ForgeAndFloraConfig
+
+__all__ = [
+    "Display",
+    "DisplayState",
+    "LEDDisplay",
+    "LEDConfig",
+    "LookingGlassDisplay",
+    "LookingGlassConfig",
+    "ForgeAndFloraDisplay",
+    "ForgeAndFloraConfig",
+]

--- a/ShowControl/TreeHouse/displays/base.py
+++ b/ShowControl/TreeHouse/displays/base.py
@@ -1,6 +1,32 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any
+
+# SK6812 RGBW — four channels, each 0-255
+Color = tuple[int, int, int, int]
+
+
+class ShowMode(Enum):
+    FULL = "full"
+    DIM = "dim"
+    OFF = "off"
+
+
+def scale_color(color: Color, factor: float) -> Color:
+    return (
+        max(0, min(255, int(color[0] * factor))),
+        max(0, min(255, int(color[1] * factor))),
+        max(0, min(255, int(color[2] * factor))),
+        max(0, min(255, int(color[3] * factor))),
+    )
+
+
+@dataclass
+class ChannelFrame:
+    """One LED strip's worth of pixel data bound to a specific Pico GPIO pin."""
+    pin: int
+    pixels: list[Color]
 
 
 @dataclass
@@ -26,8 +52,13 @@ class Display(ABC):
 
     @abstractmethod
     def update(self, dt: float) -> None:
-        """Advance internal state by *dt* seconds and push to hardware."""
+        """Advance internal state by *dt* seconds."""
+
+    @abstractmethod
+    def get_frames(self) -> list[ChannelFrame]:
+        """Return pixel data for all LED channels owned by this display.
+        Returns an empty list for non-LED displays (e.g. HDMI video)."""
 
     @abstractmethod
     def get_state(self) -> DisplayState:
-        """Return a serialisable snapshot (for logging / visualiser)."""
+        """Return a serialisable snapshot for logging / visualiser."""

--- a/ShowControl/TreeHouse/displays/base.py
+++ b/ShowControl/TreeHouse/displays/base.py
@@ -1,0 +1,33 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class DisplayState:
+    """Serialisable snapshot of one display's current state."""
+    name: str
+    enabled: bool
+    params: dict[str, Any] = field(default_factory=dict)
+
+
+class Display(ABC):
+    """Abstract base for every controllable element in the TreeHouse."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.enabled = True
+
+    def enable(self) -> None:
+        self.enabled = True
+
+    def disable(self) -> None:
+        self.enabled = False
+
+    @abstractmethod
+    def update(self, dt: float) -> None:
+        """Advance internal state by *dt* seconds and push to hardware."""
+
+    @abstractmethod
+    def get_state(self) -> DisplayState:
+        """Return a serialisable snapshot (for logging / visualiser)."""

--- a/ShowControl/TreeHouse/displays/effect.py
+++ b/ShowControl/TreeHouse/displays/effect.py
@@ -1,0 +1,132 @@
+import logging
+import math
+from dataclasses import dataclass
+
+from .base import Display, DisplayState
+
+log = logging.getLogger("treehouse")
+
+Color = tuple[int, int, int]
+
+
+@dataclass
+class ForgeAndFloraConfig:
+    name: str = "Forge & Flora"
+    # 0.0 = pure welding arc, 1.0 = pure magical gardening
+    blend: float = 0.0
+    transition_speed: float = 0.1  # blend units per second
+    flicker_intensity: float = 0.3  # random intensity for the welding flicker
+
+
+class ForgeAndFloraDisplay(Display):
+    """
+    LED effect window blending between two distinct visual states.
+
+    Welding (blend=0.0)
+    -------------------
+    Harsh blue-white electric arc with high-frequency UV flicker and orange
+    spatter sparks. Evokes a welder at work.
+
+    Magical Gardening (blend=1.0)
+    -----------------------------
+    Soft bioluminescent bloom — warm green-gold pulses and slow colour washes.
+    Evokes phosphorescent plants growing in the dark.
+
+    The transition is a smooth EMA-driven lerp so intermediate values produce
+    a coherent cross-fade rather than an abrupt switch.
+    """
+
+    _WELDING_BASE: Color = (180, 210, 255)    # cold blue-white arc
+    _WELDING_SPARK: Color = (255, 140, 20)    # hot orange spatter
+    _GARDENING_GLOW: Color = (60, 255, 100)   # bioluminescent green
+    _GARDENING_BLOOM: Color = (200, 255, 80)  # warm gold-lime bloom
+
+    def __init__(self, config: ForgeAndFloraConfig) -> None:
+        super().__init__(config.name)
+        self.blend = config.blend
+        self.transition_speed = config.transition_speed
+        self.flicker_intensity = config.flicker_intensity
+        self._target_blend = config.blend
+        self._time = 0.0
+
+    # ------------------------------------------------------------------
+    # Control interface
+    # ------------------------------------------------------------------
+
+    def set_mode(self, mode: str) -> None:
+        """Snap target blend to a named mode."""
+        modes = {"welding": 0.0, "gardening": 1.0}
+        if mode not in modes:
+            raise ValueError(f"Unknown mode {mode!r}; use {list(modes)}")
+        log.info("Forge & Flora mode → %s", mode)
+        self._target_blend = modes[mode]
+
+    def set_blend(self, blend: float) -> None:
+        """Set target blend directly (0.0–1.0)."""
+        self._target_blend = max(0.0, min(1.0, blend))
+
+    def set_transition_speed(self, speed: float) -> None:
+        self.transition_speed = max(0.0, speed)
+
+    # ------------------------------------------------------------------
+    # Colour helpers
+    # ------------------------------------------------------------------
+
+    def _lerp_color(self, a: Color, b: Color, t: float) -> Color:
+        return tuple(int(ca + (cb - ca) * t) for ca, cb in zip(a, b))  # type: ignore[return-value]
+
+    def primary_color(self) -> Color:
+        """Main output colour for the current blend position."""
+        return self._lerp_color(self._WELDING_BASE, self._GARDENING_GLOW, self.blend)
+
+    def accent_color(self) -> Color:
+        """Accent / secondary colour for the current blend position."""
+        return self._lerp_color(self._WELDING_SPARK, self._GARDENING_BLOOM, self.blend)
+
+    def flicker_value(self) -> float:
+        """
+        Welding side: rapid high-frequency noise.
+        Gardening side: slow sinusoidal breathing.
+        Blended between the two so the character of light changes with the mode.
+        """
+        # Fast flicker present when in welding mode
+        weld_flicker = (math.sin(self._time * 73.0) + math.sin(self._time * 137.0)) * 0.5
+        # Slow breathe present when in gardening mode
+        garden_breathe = math.sin(self._time * 0.8) * 0.5 + 0.5
+        raw = weld_flicker * (1.0 - self.blend) + garden_breathe * self.blend
+        return 1.0 - self.flicker_intensity * (1.0 - self.blend) + raw * self.flicker_intensity
+
+    # ------------------------------------------------------------------
+    # Display lifecycle
+    # ------------------------------------------------------------------
+
+    def update(self, dt: float) -> None:
+        if not self.enabled:
+            return
+        self._time += dt
+
+        # Smooth blend toward target
+        delta = self._target_blend - self.blend
+        step = self.transition_speed * dt
+        if abs(delta) <= step:
+            self.blend = self._target_blend
+        else:
+            self.blend += step * (1.0 if delta > 0 else -1.0)
+
+        # TODO: map primary_color(), accent_color(), flicker_value() to LED hardware
+        # (e.g. two independently addressable LED channels via sACN/DMX or serial)
+
+    def get_state(self) -> DisplayState:
+        return DisplayState(
+            name=self.name,
+            enabled=self.enabled,
+            params={
+                "blend": round(self.blend, 3),
+                "target_blend": round(self._target_blend, 3),
+                "transition_speed": self.transition_speed,
+                "primary_color": self.primary_color(),
+                "accent_color": self.accent_color(),
+                "flicker_value": round(self.flicker_value(), 3),
+                "time": round(self._time, 2),
+            },
+        )

--- a/ShowControl/TreeHouse/displays/effect.py
+++ b/ShowControl/TreeHouse/displays/effect.py
@@ -2,59 +2,50 @@ import logging
 import math
 from dataclasses import dataclass
 
-from .base import Display, DisplayState
+from .base import ChannelFrame, Color, Display, DisplayState, scale_color
 
 log = logging.getLogger("treehouse")
-
-Color = tuple[int, int, int]
 
 
 @dataclass
 class ForgeAndFloraConfig:
     name: str = "Forge & Flora"
-    # 0.0 = pure welding arc, 1.0 = pure magical gardening
-    blend: float = 0.0
+    arc_pin: int = 2
+    bloom_pin: int = 3
+    led_count: int = 48      # same count on both strips
+    blend: float = 0.0       # 0.0 = welding arc, 1.0 = magical gardening
     transition_speed: float = 0.1  # blend units per second
-    flicker_intensity: float = 0.3  # random intensity for the welding flicker
+    flicker_intensity: float = 0.3
 
 
 class ForgeAndFloraDisplay(Display):
     """
-    LED effect window blending between two distinct visual states.
+    Two-strip LED effect transitioning between welding arc and magical gardening.
 
-    Welding (blend=0.0)
-    -------------------
-    Harsh blue-white electric arc with high-frequency UV flicker and orange
-    spatter sparks. Evokes a welder at work.
+    Arc strip (arc_pin)     — cold blue-white with high-freq flicker + orange spatter bursts
+    Bloom strip (bloom_pin) — warm bioluminescent green with slow sinusoidal pulse
 
-    Magical Gardening (blend=1.0)
-    -----------------------------
-    Soft bioluminescent bloom — warm green-gold pulses and slow colour washes.
-    Evokes phosphorescent plants growing in the dark.
-
-    The transition is a smooth EMA-driven lerp so intermediate values produce
-    a coherent cross-fade rather than an abrupt switch.
+    blend = 0.0  →  arc at full, bloom off
+    blend = 1.0  →  bloom at full, arc off
+    Intermediate values cross-fade both strips simultaneously.
     """
 
-    _WELDING_BASE: Color = (180, 210, 255)    # cold blue-white arc
-    _WELDING_SPARK: Color = (255, 140, 20)    # hot orange spatter
-    _GARDENING_GLOW: Color = (60, 255, 100)   # bioluminescent green
-    _GARDENING_BLOOM: Color = (200, 255, 80)  # warm gold-lime bloom
+    _ARC_COLOR: Color   = (180, 210, 255, 200)  # cold blue-white arc
+    _SPARK_COLOR: Color = (255, 140,  20,   0)  # hot orange spatter
+    _BLOOM_COLOR: Color = ( 60, 255, 100,  50)  # bioluminescent green
 
     def __init__(self, config: ForgeAndFloraConfig) -> None:
         super().__init__(config.name)
+        self.arc_pin = config.arc_pin
+        self.bloom_pin = config.bloom_pin
+        self.led_count = config.led_count
         self.blend = config.blend
         self.transition_speed = config.transition_speed
         self.flicker_intensity = config.flicker_intensity
         self._target_blend = config.blend
         self._time = 0.0
 
-    # ------------------------------------------------------------------
-    # Control interface
-    # ------------------------------------------------------------------
-
     def set_mode(self, mode: str) -> None:
-        """Snap target blend to a named mode."""
         modes = {"welding": 0.0, "gardening": 1.0}
         if mode not in modes:
             raise ValueError(f"Unknown mode {mode!r}; use {list(modes)}")
@@ -62,50 +53,24 @@ class ForgeAndFloraDisplay(Display):
         self._target_blend = modes[mode]
 
     def set_blend(self, blend: float) -> None:
-        """Set target blend directly (0.0–1.0)."""
         self._target_blend = max(0.0, min(1.0, blend))
 
     def set_transition_speed(self, speed: float) -> None:
         self.transition_speed = max(0.0, speed)
 
-    # ------------------------------------------------------------------
-    # Colour helpers
-    # ------------------------------------------------------------------
+    def _flicker(self) -> float:
+        """Inharmonic high-freq noise for arc simulation."""
+        raw = (math.sin(self._time * 73.0) + math.sin(self._time * 137.0)) / 2.0
+        return 1.0 - self.flicker_intensity * (1.0 - (raw + 1.0) / 2.0)
 
-    def _lerp_color(self, a: Color, b: Color, t: float) -> Color:
-        return tuple(int(ca + (cb - ca) * t) for ca, cb in zip(a, b))  # type: ignore[return-value]
-
-    def primary_color(self) -> Color:
-        """Main output colour for the current blend position."""
-        return self._lerp_color(self._WELDING_BASE, self._GARDENING_GLOW, self.blend)
-
-    def accent_color(self) -> Color:
-        """Accent / secondary colour for the current blend position."""
-        return self._lerp_color(self._WELDING_SPARK, self._GARDENING_BLOOM, self.blend)
-
-    def flicker_value(self) -> float:
-        """
-        Welding side: rapid high-frequency noise.
-        Gardening side: slow sinusoidal breathing.
-        Blended between the two so the character of light changes with the mode.
-        """
-        # Fast flicker present when in welding mode
-        weld_flicker = (math.sin(self._time * 73.0) + math.sin(self._time * 137.0)) * 0.5
-        # Slow breathe present when in gardening mode
-        garden_breathe = math.sin(self._time * 0.8) * 0.5 + 0.5
-        raw = weld_flicker * (1.0 - self.blend) + garden_breathe * self.blend
-        return 1.0 - self.flicker_intensity * (1.0 - self.blend) + raw * self.flicker_intensity
-
-    # ------------------------------------------------------------------
-    # Display lifecycle
-    # ------------------------------------------------------------------
+    def _spark(self) -> float:
+        """Occasional sharp orange burst riding on top of the arc."""
+        return max(0.0, math.sin(self._time * 29.0) ** 8)
 
     def update(self, dt: float) -> None:
         if not self.enabled:
             return
         self._time += dt
-
-        # Smooth blend toward target
         delta = self._target_blend - self.blend
         step = self.transition_speed * dt
         if abs(delta) <= step:
@@ -113,8 +78,32 @@ class ForgeAndFloraDisplay(Display):
         else:
             self.blend += step * (1.0 if delta > 0 else -1.0)
 
-        # TODO: map primary_color(), accent_color(), flicker_value() to LED hardware
-        # (e.g. two independently addressable LED channels via sACN/DMX or serial)
+    def get_frames(self) -> list[ChannelFrame]:
+        empty: list[Color] = [(0, 0, 0, 0)] * self.led_count
+        if not self.enabled:
+            return [
+                ChannelFrame(pin=self.arc_pin,   pixels=list(empty)),
+                ChannelFrame(pin=self.bloom_pin, pixels=list(empty)),
+            ]
+
+        # Arc strip: base arc colour with flicker, occasional spark overlay
+        arc_base  = scale_color(self._ARC_COLOR,   (1.0 - self.blend) * self._flicker())
+        spark     = scale_color(self._SPARK_COLOR, (1.0 - self.blend) * self._spark())
+        arc_color: Color = (
+            min(255, arc_base[0] + spark[0]),
+            min(255, arc_base[1] + spark[1]),
+            min(255, arc_base[2] + spark[2]),
+            min(255, arc_base[3] + spark[3]),
+        )
+
+        # Bloom strip: slow sinusoidal breathing
+        bloom_pulse = (math.sin(self._time * 0.8) + 1.0) / 2.0
+        bloom_color = scale_color(self._BLOOM_COLOR, self.blend * (0.7 + 0.3 * bloom_pulse))
+
+        return [
+            ChannelFrame(pin=self.arc_pin,   pixels=[arc_color]   * self.led_count),
+            ChannelFrame(pin=self.bloom_pin, pixels=[bloom_color]  * self.led_count),
+        ]
 
     def get_state(self) -> DisplayState:
         return DisplayState(
@@ -124,9 +113,9 @@ class ForgeAndFloraDisplay(Display):
                 "blend": round(self.blend, 3),
                 "target_blend": round(self._target_blend, 3),
                 "transition_speed": self.transition_speed,
-                "primary_color": self.primary_color(),
-                "accent_color": self.accent_color(),
-                "flicker_value": round(self.flicker_value(), 3),
+                "arc_pin": self.arc_pin,
+                "bloom_pin": self.bloom_pin,
+                "led_count": self.led_count,
                 "time": round(self._time, 2),
             },
         )

--- a/ShowControl/TreeHouse/displays/led.py
+++ b/ShowControl/TreeHouse/displays/led.py
@@ -1,45 +1,45 @@
 import logging
-from dataclasses import dataclass, field
+import math
+from dataclasses import dataclass
 
-from .base import Display, DisplayState
+from .base import ChannelFrame, Color, Display, DisplayState, scale_color
 
 log = logging.getLogger("treehouse")
-
-Color = tuple[int, int, int]  # RGB 0–255
 
 
 @dataclass
 class LEDConfig:
     name: str
+    pico_pin: int
+    led_count: int
     brightness: float = 1.0
-    color: Color = (255, 255, 255)
+    color: Color = (0, 0, 0, 255)  # pure white via the W channel
     pattern: str = "solid"
 
 
 class LEDDisplay(Display):
     """
-    Generic LED panel — used for diorama boxes, gable windows, and the dormer.
+    Generic SK6812 LED strip — diorama boxes, gable windows, dormer.
 
     Patterns
     --------
-    solid   – static colour at set brightness
-    breathe – sinusoidal fade in/out
-    strobe  – rapid on/off flash
-    chase   – sweeping pixel movement (hardware-dependent)
+    solid        – static colour at set brightness
+    breathe      – sinusoidal fade in/out (~4 s cycle)
+    strobe       – 10 Hz on/off flash
+    chase        – lit head travels the strip with a fading 6-pixel trail
+    incandescent – barely-perceptible flicker simulating a warm bulb
     """
 
-    PATTERNS = ("solid", "breathe", "strobe", "chase")
+    PATTERNS = ("solid", "breathe", "strobe", "chase", "incandescent")
 
     def __init__(self, config: LEDConfig) -> None:
         super().__init__(config.name)
+        self.pico_pin = config.pico_pin
+        self.led_count = config.led_count
         self.brightness = config.brightness
         self.color: Color = config.color
         self.pattern = config.pattern
         self._time = 0.0
-
-    # ------------------------------------------------------------------
-    # Control interface
-    # ------------------------------------------------------------------
 
     def set_color(self, color: Color) -> None:
         self.color = color
@@ -52,22 +52,55 @@ class LEDDisplay(Display):
             raise ValueError(f"Unknown pattern {pattern!r}; choices: {self.PATTERNS}")
         self.pattern = pattern
 
-    # ------------------------------------------------------------------
-    # Display lifecycle
-    # ------------------------------------------------------------------
-
     def update(self, dt: float) -> None:
         if not self.enabled:
             return
         self._time += dt
-        # TODO: compute effective brightness from pattern and push to hardware
-        # (e.g. via sACN/DMX, serial, or OSC)
+
+    def _base_color(self) -> Color:
+        return scale_color(self.color, self.brightness)
+
+    def _compute_pixels(self) -> list[Color]:
+        base = self._base_color()
+
+        if self.pattern == "breathe":
+            factor = (math.sin(self._time * math.pi / 2.0) + 1.0) / 2.0
+            return [scale_color(base, factor)] * self.led_count
+
+        if self.pattern == "strobe":
+            on = (int(self._time * 10) % 2 == 0)
+            return [base if on else (0, 0, 0, 0)] * self.led_count
+
+        if self.pattern == "chase":
+            pixels: list[Color] = [(0, 0, 0, 0)] * self.led_count
+            head = int(self._time * 20) % self.led_count
+            trail = 6
+            for i in range(trail):
+                idx = (head - i) % self.led_count
+                pixels[idx] = scale_color(base, 1.0 - i / trail)
+            return pixels
+
+        if self.pattern == "incandescent":
+            # Two inharmonic sines produce irregular flicker without obvious periodicity
+            noise = (math.sin(self._time * 7.3) + math.sin(self._time * 13.7)) / 2.0
+            factor = 1.0 - 0.015 * (noise + 1.0) / 2.0
+            return [scale_color(base, factor)] * self.led_count
+
+        return [base] * self.led_count  # solid
+
+    def get_frames(self) -> list[ChannelFrame]:
+        off: list[Color] = [(0, 0, 0, 0)] * self.led_count
+        if not self.enabled:
+            return [ChannelFrame(pin=self.pico_pin, pixels=off)]
+        return [ChannelFrame(pin=self.pico_pin, pixels=self._compute_pixels())]
 
     def get_state(self) -> DisplayState:
         return DisplayState(
             name=self.name,
             enabled=self.enabled,
             params={
+                "pico_pin": self.pico_pin,
+                "led_count": self.led_count,
                 "color": self.color,
                 "brightness": round(self.brightness, 3),
                 "pattern": self.pattern,

--- a/ShowControl/TreeHouse/displays/led.py
+++ b/ShowControl/TreeHouse/displays/led.py
@@ -1,0 +1,76 @@
+import logging
+from dataclasses import dataclass, field
+
+from .base import Display, DisplayState
+
+log = logging.getLogger("treehouse")
+
+Color = tuple[int, int, int]  # RGB 0–255
+
+
+@dataclass
+class LEDConfig:
+    name: str
+    brightness: float = 1.0
+    color: Color = (255, 255, 255)
+    pattern: str = "solid"
+
+
+class LEDDisplay(Display):
+    """
+    Generic LED panel — used for diorama boxes, gable windows, and the dormer.
+
+    Patterns
+    --------
+    solid   – static colour at set brightness
+    breathe – sinusoidal fade in/out
+    strobe  – rapid on/off flash
+    chase   – sweeping pixel movement (hardware-dependent)
+    """
+
+    PATTERNS = ("solid", "breathe", "strobe", "chase")
+
+    def __init__(self, config: LEDConfig) -> None:
+        super().__init__(config.name)
+        self.brightness = config.brightness
+        self.color: Color = config.color
+        self.pattern = config.pattern
+        self._time = 0.0
+
+    # ------------------------------------------------------------------
+    # Control interface
+    # ------------------------------------------------------------------
+
+    def set_color(self, color: Color) -> None:
+        self.color = color
+
+    def set_brightness(self, brightness: float) -> None:
+        self.brightness = max(0.0, min(1.0, brightness))
+
+    def set_pattern(self, pattern: str) -> None:
+        if pattern not in self.PATTERNS:
+            raise ValueError(f"Unknown pattern {pattern!r}; choices: {self.PATTERNS}")
+        self.pattern = pattern
+
+    # ------------------------------------------------------------------
+    # Display lifecycle
+    # ------------------------------------------------------------------
+
+    def update(self, dt: float) -> None:
+        if not self.enabled:
+            return
+        self._time += dt
+        # TODO: compute effective brightness from pattern and push to hardware
+        # (e.g. via sACN/DMX, serial, or OSC)
+
+    def get_state(self) -> DisplayState:
+        return DisplayState(
+            name=self.name,
+            enabled=self.enabled,
+            params={
+                "color": self.color,
+                "brightness": round(self.brightness, 3),
+                "pattern": self.pattern,
+                "time": round(self._time, 2),
+            },
+        )

--- a/ShowControl/TreeHouse/displays/video.py
+++ b/ShowControl/TreeHouse/displays/video.py
@@ -1,0 +1,80 @@
+import logging
+from dataclasses import dataclass
+
+from .base import Display, DisplayState
+
+log = logging.getLogger("treehouse")
+
+
+@dataclass
+class LookingGlassConfig:
+    name: str = "Looking Glass"
+    scene: str = "bloom"
+    speed: float = 1.0
+    # Number of virtual mirror reflections rendered by the video engine
+    mirror_depth: int = 6
+
+
+class LookingGlassDisplay(Display):
+    """
+    Generative video inside a physical mirrored box ('Looking Glass' garage window).
+
+    The mirrored enclosure multiplies every rendered frame into an infinite-
+    regression tunnel. The video engine receives scene parameters each frame
+    via the control interface below.
+
+    Scenes
+    ------
+    bloom     – slow organic growth spirals
+    fractal   – recursive geometric growth
+    mycelium  – branching network propagation
+    cosmos    – stellar nebula drift
+    """
+
+    SCENES = ("bloom", "fractal", "mycelium", "cosmos")
+
+    def __init__(self, config: LookingGlassConfig) -> None:
+        super().__init__(config.name)
+        self.scene = config.scene
+        self.speed = config.speed
+        self.mirror_depth = config.mirror_depth
+        self._time = 0.0
+
+    # ------------------------------------------------------------------
+    # Control interface
+    # ------------------------------------------------------------------
+
+    def set_scene(self, scene: str) -> None:
+        if scene not in self.SCENES:
+            raise ValueError(f"Unknown scene {scene!r}; choices: {self.SCENES}")
+        log.info("Looking Glass scene → %s", scene)
+        self.scene = scene
+
+    def set_speed(self, speed: float) -> None:
+        self.speed = max(0.0, speed)
+
+    def set_mirror_depth(self, depth: int) -> None:
+        self.mirror_depth = max(1, depth)
+
+    # ------------------------------------------------------------------
+    # Display lifecycle
+    # ------------------------------------------------------------------
+
+    def update(self, dt: float) -> None:
+        if not self.enabled:
+            return
+        self._time += dt * self.speed
+        # TODO: push {scene, time, mirror_depth} to video renderer each frame
+        # (e.g. via OSC, shared-memory texture, or socket to a TouchDesigner patch)
+
+    def get_state(self) -> DisplayState:
+        return DisplayState(
+            name=self.name,
+            enabled=self.enabled,
+            params={
+                "scene": self.scene,
+                "speed": self.speed,
+                "mirror_depth": self.mirror_depth,
+                "time": round(self._time, 2),
+            },
+        )

--- a/ShowControl/TreeHouse/displays/video.py
+++ b/ShowControl/TreeHouse/displays/video.py
@@ -1,7 +1,7 @@
 import logging
 from dataclasses import dataclass
 
-from .base import Display, DisplayState
+from .base import ChannelFrame, Display, DisplayState
 
 log = logging.getLogger("treehouse")
 
@@ -66,6 +66,9 @@ class LookingGlassDisplay(Display):
         self._time += dt * self.speed
         # TODO: push {scene, time, mirror_depth} to video renderer each frame
         # (e.g. via OSC, shared-memory texture, or socket to a TouchDesigner patch)
+
+    def get_frames(self) -> list[ChannelFrame]:
+        return []  # HDMI output — no Pico channel
 
     def get_state(self) -> DisplayState:
         return DisplayState(

--- a/ShowControl/TreeHouse/main.py
+++ b/ShowControl/TreeHouse/main.py
@@ -1,0 +1,57 @@
+"""
+TreeHouse show control — entry point.
+
+Drives the per-frame update loop for all display elements:
+  3× diorama boxes  (House Swarming, Mycellium, Club)
+  2× garage windows (Looking Glass, Forge & Flora)
+  2× gable windows  (Front Gable, Back Gable)
+  1× dormer window  (Dormer)
+"""
+
+import argparse
+import logging
+import time
+
+from coordinator import Coordinator, build_displays, load_config
+
+log = logging.getLogger("treehouse")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="TreeHouse show control")
+    p.add_argument("--config", default="settings.json", help="Path to settings JSON")
+    p.add_argument("--fps", type=int, default=30, help="Target update rate (default: 30)")
+    p.add_argument("--verbose", "-v", action="store_true", help="Enable DEBUG logging")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s [%(name)s] %(levelname)s %(message)s",
+    )
+
+    config = load_config(args.config)
+    displays = build_displays(config)
+    coordinator = Coordinator(displays)
+
+    log.info("TreeHouse show control starting — %d displays", len(displays))
+    for name in coordinator.display_names:
+        log.info("  • %s", name)
+
+    dt = 1.0 / args.fps
+    try:
+        while True:
+            t0 = time.monotonic()
+            coordinator.update(dt)
+            elapsed = time.monotonic() - t0
+            remaining = dt - elapsed
+            if remaining > 0:
+                time.sleep(remaining)
+    except KeyboardInterrupt:
+        log.info("Shutting down.")
+
+
+if __name__ == "__main__":
+    main()

--- a/ShowControl/TreeHouse/main.py
+++ b/ShowControl/TreeHouse/main.py
@@ -2,17 +2,22 @@
 TreeHouse show control — entry point.
 
 Drives the per-frame update loop for all display elements:
-  3× diorama boxes  (House Swarming, Mycellium, Club)
-  2× garage windows (Looking Glass, Forge & Flora)
-  2× gable windows  (Front Gable, Back Gable)
-  1× dormer window  (Dormer)
+  2× diorama boxes   (House Swarming, Club)
+  2× garage windows  (Looking Glass, Forge & Flora)
+  2× gable windows   (Front Gable, Back Gable)
+  1× dormer window   (Dormer)
+
+Receives OSC from the festival network to manage show modes.
+Sends LED pixel data to the Pi Pico over USB serial each frame.
 """
 
 import argparse
+import asyncio
 import logging
-import time
 
 from coordinator import Coordinator, build_displays, load_config
+from osc_server import serve as serve_osc
+from pico_driver import PicoDriver
 
 log = logging.getLogger("treehouse")
 
@@ -20,9 +25,44 @@ log = logging.getLogger("treehouse")
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="TreeHouse show control")
     p.add_argument("--config", default="settings.json", help="Path to settings JSON")
-    p.add_argument("--fps", type=int, default=30, help="Target update rate (default: 30)")
+    p.add_argument("--no-pico", action="store_true", help="Skip Pico connection (dev mode)")
+    p.add_argument("--no-osc", action="store_true", help="Skip OSC listener")
     p.add_argument("--verbose", "-v", action="store_true", help="Enable DEBUG logging")
     return p.parse_args()
+
+
+async def _frame_loop(coordinator: Coordinator, driver: PicoDriver, fps: int) -> None:
+    dt = 1.0 / fps
+    loop = asyncio.get_running_loop()
+    while True:
+        t0 = loop.time()
+        coordinator.update(dt)
+        driver.send_frames(coordinator.get_all_frames(), coordinator.brightness)
+        await asyncio.sleep(max(0.0, dt - (loop.time() - t0)))
+
+
+async def _run(args: argparse.Namespace) -> None:
+    config = load_config(args.config)
+    displays = build_displays(config)
+    coordinator = Coordinator(displays)
+    coordinator._dim_level = config.show.dim_level
+
+    driver = PicoDriver(config.pico.port, config.pico.baud)
+    if not args.no_pico:
+        driver.connect()
+
+    log.info("TreeHouse starting — %d displays", len(displays))
+    for name in coordinator.display_names:
+        log.info("  • %s", name)
+
+    tasks = [asyncio.create_task(_frame_loop(coordinator, driver, config.show.fps))]
+    if not args.no_osc:
+        tasks.append(asyncio.create_task(serve_osc(coordinator, config.osc.listen_port)))
+
+    try:
+        await asyncio.gather(*tasks)
+    finally:
+        driver.close()
 
 
 def main() -> None:
@@ -31,24 +71,8 @@ def main() -> None:
         level=logging.DEBUG if args.verbose else logging.INFO,
         format="%(asctime)s [%(name)s] %(levelname)s %(message)s",
     )
-
-    config = load_config(args.config)
-    displays = build_displays(config)
-    coordinator = Coordinator(displays)
-
-    log.info("TreeHouse show control starting — %d displays", len(displays))
-    for name in coordinator.display_names:
-        log.info("  • %s", name)
-
-    dt = 1.0 / args.fps
     try:
-        while True:
-            t0 = time.monotonic()
-            coordinator.update(dt)
-            elapsed = time.monotonic() - t0
-            remaining = dt - elapsed
-            if remaining > 0:
-                time.sleep(remaining)
+        asyncio.run(_run(args))
     except KeyboardInterrupt:
         log.info("Shutting down.")
 

--- a/ShowControl/TreeHouse/osc_server.py
+++ b/ShowControl/TreeHouse/osc_server.py
@@ -1,0 +1,54 @@
+"""
+OSC server — receives show-control messages from other festival elements.
+
+Recognised addresses
+--------------------
+/treehouse/mode       <string>   "full" | "dim" | "off"
+/treehouse/brightness <float>    0.0–1.0  (overrides the dim level in config)
+
+Additional addresses for individual display control can be added to the
+dispatcher below as the festival programme is finalised.
+"""
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from pythonosc.dispatcher import Dispatcher
+from pythonosc.osc_server import AsyncIOOSCUDPServer
+
+if TYPE_CHECKING:
+    from coordinator import Coordinator
+
+log = logging.getLogger("treehouse")
+
+
+def _build_dispatcher(coordinator: "Coordinator") -> Dispatcher:
+    d = Dispatcher()
+
+    def on_mode(address: str, mode: str) -> None:
+        log.info("OSC %s → %r", address, mode)
+        coordinator.set_mode(mode)
+
+    def on_brightness(address: str, level: float) -> None:
+        log.info("OSC %s → %.2f", address, level)
+        coordinator.set_dim_level(float(level))
+
+    d.map("/treehouse/mode", on_mode)
+    d.map("/treehouse/brightness", on_brightness)
+    d.set_default_handler(
+        lambda addr, *args: log.debug("OSC unhandled: %s %s", addr, args)
+    )
+    return d
+
+
+async def serve(coordinator: "Coordinator", port: int) -> None:
+    loop = asyncio.get_running_loop()
+    dispatcher = _build_dispatcher(coordinator)
+    server = AsyncIOOSCUDPServer(("0.0.0.0", port), dispatcher, loop)
+    transport, _ = await server.create_serve_endpoint()
+    log.info("OSC server listening on :%d", port)
+    try:
+        await asyncio.sleep(float("inf"))
+    finally:
+        transport.close()

--- a/ShowControl/TreeHouse/pico_driver.py
+++ b/ShowControl/TreeHouse/pico_driver.py
@@ -1,0 +1,55 @@
+import json
+import logging
+
+import serial
+
+from displays.base import ChannelFrame, Color, scale_color
+
+log = logging.getLogger("treehouse")
+
+
+class PicoDriver:
+    """
+    Sends LED frame data to the Pi Pico over USB serial.
+
+    Protocol — one newline-delimited JSON object per strip per frame:
+
+        {"pin": <int>, "pixels": [[r, g, b, w], ...]}
+
+    The Pico firmware reads each line, identifies the SK6812 strip on that
+    GPIO pin, and writes the pixel data out via PIO DMA.  The Pi 5 does not
+    wait for an acknowledgement; frames are fire-and-forget at 30 fps.
+
+    If the serial port is unavailable (dev mode, cable unplugged) the driver
+    logs a warning and silently drops frames rather than crashing the loop.
+    """
+
+    def __init__(self, port: str, baud: int = 115200) -> None:
+        self._port = port
+        self._baud = baud
+        self._serial: serial.Serial | None = None
+
+    def connect(self) -> None:
+        try:
+            self._serial = serial.Serial(self._port, self._baud, timeout=1)
+            log.info("Pico connected on %s @ %d baud", self._port, self._baud)
+        except serial.SerialException as e:
+            log.warning("Pico not available (%s) — LED output disabled", e)
+
+    def send_frames(self, frames: list[ChannelFrame], brightness: float = 1.0) -> None:
+        if not self._serial or not self._serial.is_open:
+            return
+        for frame in frames:
+            scaled: list[list[int]] = [list(scale_color(p, brightness)) for p in frame.pixels]
+            line = json.dumps({"pin": frame.pin, "pixels": scaled}) + "\n"
+            try:
+                self._serial.write(line.encode())
+            except serial.SerialException as e:
+                log.error("Pico write error: %s — LED output suspended", e)
+                self._serial = None
+                return
+
+    def close(self) -> None:
+        if self._serial and self._serial.is_open:
+            self._serial.close()
+            log.info("Pico disconnected")

--- a/ShowControl/TreeHouse/requirements.txt
+++ b/ShowControl/TreeHouse/requirements.txt
@@ -1,0 +1,7 @@
+# No runtime dependencies yet — add as hardware integrations are wired up.
+#
+# Likely candidates:
+#   python-osc      — OSC messaging to Arduino LED controllers
+#   sacn            — sACN / E1.31 for DMX lighting
+#   pyserial        — direct serial to LED strips
+#   opencv-python   — generative video / computer vision for Looking Glass

--- a/ShowControl/TreeHouse/requirements.txt
+++ b/ShowControl/TreeHouse/requirements.txt
@@ -1,7 +1,2 @@
-# No runtime dependencies yet — add as hardware integrations are wired up.
-#
-# Likely candidates:
-#   python-osc      — OSC messaging to Arduino LED controllers
-#   sacn            — sACN / E1.31 for DMX lighting
-#   pyserial        — direct serial to LED strips
-#   opencv-python   — generative video / computer vision for Looking Glass
+python-osc
+pyserial

--- a/ShowControl/TreeHouse/settings.json
+++ b/ShowControl/TreeHouse/settings.json
@@ -1,24 +1,43 @@
 {
+  "pico": {
+    "port": "/dev/ttyACM0",
+    "baud": 115200
+  },
+
+  "osc": {
+    "listen_port": 9001
+  },
+
+  "show": {
+    "fps": 30,
+    "dim_level": 0.25
+  },
+
   "dioramas": [
     {
       "name": "House Swarming",
+      "pico_pin": 0,
+      "led_count": 146,
       "brightness": 1.0,
-      "color": [255, 255, 255],
-      "pattern": "solid"
-    },
-    {
-      "name": "Mycellium",
-      "brightness": 1.0,
-      "color": [80, 255, 120],
-      "pattern": "breathe"
+      "color": [255, 180, 80, 255],
+      "pattern": "incandescent"
     },
     {
       "name": "Club",
+      "pico_pin": 1,
+      "led_count": 24,
       "brightness": 1.0,
-      "color": [255, 50, 200],
+      "color": [180, 0, 255, 0],
       "pattern": "chase"
     }
   ],
+
+  "_shelved": {
+    "mycellium": {
+      "note": "Pending prototype. When ready: add to dioramas[], pico_pin: 2, pattern: breathe.",
+      "color": [80, 255, 120, 50]
+    }
+  },
 
   "garage_windows": {
     "looking_glass": {
@@ -29,6 +48,9 @@
     },
     "forge_and_flora": {
       "name": "Forge & Flora",
+      "arc_pin": 2,
+      "bloom_pin": 3,
+      "led_count": 48,
       "blend": 0.0,
       "transition_speed": 0.1,
       "flicker_intensity": 0.3
@@ -38,22 +60,28 @@
   "gable_windows": {
     "front": {
       "name": "Front Gable",
-      "brightness": 1.0,
-      "color": [255, 255, 255],
+      "pico_pin": 4,
+      "led_count": 46,
+      "brightness": 0.8,
+      "color": [0, 0, 0, 255],
       "pattern": "solid"
     },
     "back": {
       "name": "Back Gable",
-      "brightness": 1.0,
-      "color": [255, 255, 255],
+      "pico_pin": 5,
+      "led_count": 46,
+      "brightness": 0.8,
+      "color": [0, 0, 0, 255],
       "pattern": "solid"
     }
   },
 
   "dormer": {
     "name": "Dormer",
-    "brightness": 1.0,
-    "color": [255, 255, 255],
+    "pico_pin": 6,
+    "led_count": 90,
+    "brightness": 0.8,
+    "color": [0, 0, 0, 255],
     "pattern": "solid"
   }
 }

--- a/ShowControl/TreeHouse/settings.json
+++ b/ShowControl/TreeHouse/settings.json
@@ -1,0 +1,59 @@
+{
+  "dioramas": [
+    {
+      "name": "House Swarming",
+      "brightness": 1.0,
+      "color": [255, 255, 255],
+      "pattern": "solid"
+    },
+    {
+      "name": "Mycellium",
+      "brightness": 1.0,
+      "color": [80, 255, 120],
+      "pattern": "breathe"
+    },
+    {
+      "name": "Club",
+      "brightness": 1.0,
+      "color": [255, 50, 200],
+      "pattern": "chase"
+    }
+  ],
+
+  "garage_windows": {
+    "looking_glass": {
+      "name": "Looking Glass",
+      "scene": "bloom",
+      "speed": 1.0,
+      "mirror_depth": 6
+    },
+    "forge_and_flora": {
+      "name": "Forge & Flora",
+      "blend": 0.0,
+      "transition_speed": 0.1,
+      "flicker_intensity": 0.3
+    }
+  },
+
+  "gable_windows": {
+    "front": {
+      "name": "Front Gable",
+      "brightness": 1.0,
+      "color": [255, 255, 255],
+      "pattern": "solid"
+    },
+    "back": {
+      "name": "Back Gable",
+      "brightness": 1.0,
+      "color": [255, 255, 255],
+      "pattern": "solid"
+    }
+  },
+
+  "dormer": {
+    "name": "Dormer",
+    "brightness": 1.0,
+    "color": [255, 255, 255],
+    "pattern": "solid"
+  }
+}


### PR DESCRIPTION
Stubs out an extensible display-control system for the TreeHouse installation:

  Dioramas (LED)   — House Swarming, Mycellium, Club
  Garage windows   — Looking Glass (generative video in mirrored box)
                     Forge & Flora (LED: welding arc ↔ magical gardening)
  Gable windows    — Front Gable, Back Gable
  Dormer           — Dormer

Architecture mirrors FlowerBeds: Display ABC in displays/base.py, concrete
types in displays/led.py, displays/video.py, displays/effect.py, wired by
Coordinator in coordinator.py, driven by main.py. All config lives in
settings.json. Hardware integration points are marked with TODO comments.

https://claude.ai/code/session_01LYgHdHtDzdL5w7EsC5jo9Q