### PR TITLE
Remove Unreal Engine conventions, standardize on Orbbec coordinate system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ CommunityGarden/
 │       ├── blob_tracker.py    # Depth-frame blob detection (background subtraction + 3D unproject)
 │       ├── blob_stabilizer.py # Cross-frame tracking with EMA smoothing
 │       ├── camera.py          # Orbbec camera + MockCamera abstraction
-│       ├── transforms.py      # UE-style coordinate math (UETransform, UERotator, etc.)
+│       ├── transforms.py      # World-space coordinate helpers (Transform, Rotator, etc.)
 │       ├── visualizer.py      # FastAPI/WebSocket live top-down debug view
 │       ├── settings.json      # Runtime configuration (cameras, modules, controllers)
 │       └── requirements.txt   # Python dependencies
@@ -70,27 +70,29 @@ CommunityGarden/
 | `blob_tracker.py` | `BlobTracker` — stateful per-camera blob detection; `Blob2D`, `Blob3D`, `FramePacket` |
 | `blob_stabilizer.py` | `BlobStabilizer` — cross-frame ID assignment and EMA de-jittering |
 | `camera.py` | `OrbbecCamera`, `MockCamera` — frame iterator abstraction |
-| `transforms.py` | `UETransform`, `UERotator`, coordinate conversion helpers |
+| `transforms.py` | `Transform`, `Rotator`, coordinate conversion helpers |
 | `visualizer.py` | FastAPI WebSocket server; `broadcast(state)` called each frame |
 
 ### Coordinate System
 
-All world positions use UE-style coordinates: **X=forward, Y=right, Z=up, centimetres**.
+**World space** (installation frame): **X=right, Y=forward, Z=up, centimetres** — right-handed, matching the Orbbec camera's axis conventions.
 
-Camera-space coordinates (from the depth sensor) use: **X=right, Y=down, Z=forward, metres**.
+**Camera space** (Orbbec native output): **X=right, Y=down, Z=forward, metres**.
 
-`Blob3D.world_pos_cm()` handles the conversion between these spaces.
+`Blob3D.world_pos_cm()` converts from camera space to world space:
+- World X ← Camera X (right → right)
+- World Y ← Camera Z (forward → forward)
+- World Z ← −Camera Y (up = −down)
 
-### Config Types
+### Rotation Convention
 
-Config dataclasses in `flower_beds.py` mirror the former C++ settings structs:
+`Rotator` stores pitch/yaw/roll in degrees:
+- **Pitch** — rotation around X (right) axis; positive = nose up
+- **Yaw** — rotation around Z (up) axis; positive = rotate from forward toward right
+- **Roll** — rotation around Y (forward) axis
+- Applied intrinsically in order: Roll → Pitch → Yaw
 
-| Python class | Former C++ struct |
-|---|---|
-| `ClusterConfig` | `FFlowerClusterConfig` |
-| `ModuleConfig` | `FFlowerModuleConfig` |
-| `ControllerConfig` | `FFlowerControllerConfig` |
-| `CameraConfig` | (formerly in `UBlobTrackerSettings`) |
+Yaw of 0° means facing +Y (forward). Yaw of 90° means facing +X (right).
 
 ### Logging
 
@@ -117,7 +119,7 @@ camera.frames()
   → BlobTracker.detect(frame)          # background subtraction + 3D unproject
   → transform_position(camera_transform, blob.world_pos_cm())   # camera → world space
   → BlobStabilizer.update(raw_positions)  # ID assignment + EMA smoothing
-  → Coordinator.process_world_positions(tracked_positions)       # cluster assignment
+  → Coordinator.process_tracked_blobs(tracked_positions)        # cluster assignment
   → FlowerController.send_all(commands)   # OSC → Arduino
   → visualizer.broadcast(state)           # WebSocket → browser
 ```
@@ -129,7 +131,7 @@ camera.frames()
 1. **Background subtraction** — per-pixel depth delta vs median background
 2. **Majority filter ×2** — 3×3 neighbourhood despeckle
 3. **Connected components** — 8-connected blobs via `scipy.ndimage.label`
-4. **3D unproject** — pinhole model, median-Z windowing, camera → UE coordinate conversion
+4. **3D unproject** — pinhole model, median-Z windowing, camera → world coordinate conversion
 
 Calibration collects `N` frames (configurable via `calibration_frames` in `settings.json`) to build a per-pixel median background and validity mask.
 
@@ -144,9 +146,9 @@ Calibration collects `N` frames (configurable via `calibration_frames` in `setti
 ### Coordinator Pattern
 
 `Coordinator` holds a list of `FlowerModule` objects. Each `FlowerModule` holds a list of `FlowerCluster` objects. Each frame:
-1. `Coordinator.process_world_positions(positions)` fans out to all modules
-2. `FlowerModule.update(positions)` fans out to all clusters
-3. `FlowerCluster.update(positions)` finds nearest blob, computes yaw, returns `MotorCommand`
+1. `Coordinator.process_tracked_blobs(blobs)` fans out to all modules
+2. `FlowerModule.update(blobs)` fans out to all clusters
+3. `FlowerCluster.update(blobs)` finds nearest blob, computes yaw, returns `MotorCommand`
 
 ### OSC Communication Flow
 
@@ -185,12 +187,12 @@ The Arduino firmware listens on `/cg/ff/rot` and calls `setRotDeg()` to drive th
 
   "modules": [
     {
-      "registration_point_cm": [-200.0, 100.0, 0.0],
+      "registration_point_cm": [100.0, -200.0, 0.0],
       "rotation": {"pitch": 0, "yaw": 0, "roll": 0},
       "clusters": [
         {
           "motor_id": 1,
-          "pos_offset_cm": [0.0, 40.0, 0.0],
+          "pos_offset_cm": [40.0, 0.0, 0.0],
           "rotation_offset": {"pitch": 0, "yaw": 0, "roll": 0}
         }
       ]
@@ -200,7 +202,7 @@ The Arduino firmware listens on `/cg/ff/rot` and calls `setRotDeg()` to drive th
   "cameras": [
     {
       "name": "Entrance",
-      "pos_cm": [-300.0, 0.0, 200.0],
+      "pos_cm": [0.0, -300.0, 200.0],
       "rotation": {"pitch": -30.0, "yaw": 0.0, "roll": 0.0},
       "serial": "CPCG853000CB",
       "width": 640,
@@ -213,7 +215,8 @@ The Arduino firmware listens on `/cg/ff/rot` and calls `setRotDeg()` to drive th
 
 - `motor_id` must match the Dynamixel servo ID configured via the `Dynamixel_Config` firmware.
 - `serial` must match the serial printed on the Orbbec device. Leave empty to use the first detected camera.
-- `registration_point_cm` is the physical anchor of each module in world space (centimetres).
+- `registration_point_cm` is the physical anchor of each module in world space (centimetres). X=right, Y=forward, Z=up.
+- All position vectors use the world coordinate system: **[X_right, Y_forward, Z_up]** in centimetres.
 
 ### Network Setup
 
@@ -308,7 +311,7 @@ git push -u origin <branch-name>
 ## Key Things to Know Before Making Changes
 
 1. **OSC address is `/cg/ff/rot`.** `flower_controller.py` and the Arduino firmware (`FlowerBeds_Follow_ServoController.ino`) must agree on this address — change it in both places if needed.
-2. **Coordinate system is UE-style.** World space uses X=forward, Y=right, Z=up in centimetres. Camera space uses X=right, Y=down, Z=forward in metres. `Blob3D.world_pos_cm()` converts between them.
+2. **World coordinate system: X=right, Y=forward, Z=up, centimetres.** Camera space (Orbbec native) is X=right, Y=down, Z=forward in metres. `Blob3D.world_pos_cm()` converts between them.
 3. **Dynamixel motor IDs must match config.** `ClusterConfig.motor_id` in `settings.json` must match the ID programmed into the servo hardware.
 4. **Do not hardcode network addresses, positions, or motor IDs** — they all belong in `settings.json`.
 5. **Mock mode** (`--mock`) works without any hardware and is the fastest way to test logic changes.

--- a/ShowControl/FlowerBeds/blob_tracker.py
+++ b/ShowControl/FlowerBeds/blob_tracker.py
@@ -1,5 +1,5 @@
 """
-Port of IIVision FBlobTracker to Python/numpy.
+Depth-frame blob tracker.
 
 Pipeline per frame:
   1. SubtractBackground  — depth delta threshold
@@ -81,20 +81,20 @@ class Blob3D:
     sample_count: int = 0
 
     def world_pos_cm(self) -> np.ndarray:
-        """Convert to UE world space (X=forward, Y=right, Z=up), centimetres."""
+        """Convert to world space (X=right, Y=forward, Z=up), centimetres."""
         # camera: X=right, Y=down, Z=forward
-        # UE:     X=forward, Y=right, Z=up
+        # world:  X=right, Y=forward, Z=up
         return np.array([
-            self.cam_pos_m[2] * 100.0,   # UE X ← cam Z
-            self.cam_pos_m[0] * 100.0,   # UE Y ← cam X
-            -self.cam_pos_m[1] * 100.0,  # UE Z ← -cam Y
+            self.cam_pos_m[0] * 100.0,   # world X ← cam X (right)
+            self.cam_pos_m[2] * 100.0,   # world Y ← cam Z (forward)
+            -self.cam_pos_m[1] * 100.0,  # world Z ← -cam Y (up = -down)
         ])
 
     def world_half_extents_cm(self) -> np.ndarray:
         return np.array([
-            self.cam_half_extents_m[2] * 100.0,
             self.cam_half_extents_m[0] * 100.0,
-            -self.cam_half_extents_m[1] * 100.0,
+            self.cam_half_extents_m[2] * 100.0,
+            self.cam_half_extents_m[1] * 100.0,
         ])
 
 

--- a/ShowControl/FlowerBeds/flower_beds.py
+++ b/ShowControl/FlowerBeds/flower_beds.py
@@ -1,12 +1,7 @@
 """
 Core flower-bed logic: cluster assignment and look-angle calculation.
 
-Mirrors the C++ classes:
-  AFlowerCluster  → FlowerCluster
-  AFlowerModule   → FlowerModule
-  (coordinator loop lives in main.py / Coordinator)
-
-All positions are in UE world space (X=forward, Y=right, Z=up, centimetres).
+All positions are in world space (X=right, Y=forward, Z=up, centimetres).
 """
 
 from __future__ import annotations
@@ -17,15 +12,14 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from transforms import UERotator, UETransform, look_yaw_degrees, rotator_to_matrix
+from transforms import Rotator, Transform, look_yaw_degrees, rotator_to_matrix
 
 if TYPE_CHECKING:
     from blob_stabilizer import TrackedBlob
 
 
 # ---------------------------------------------------------------------------
-# Config types  (mirror FFlowerClusterConfig / FFlowerModuleConfig /
-#                FFlowerControllerConfig from FlowerBedSettings.h)
+# Config types
 # ---------------------------------------------------------------------------
 
 @dataclass
@@ -197,15 +191,11 @@ class FlowerCluster:
 # ---------------------------------------------------------------------------
 
 class FlowerModule:
-    """
-    A physical module containing several clusters.
-
-    Mirrors AFlowerModule::Init + UpdateClusterTargets.
-    """
+    """A physical module containing several clusters."""
 
     def __init__(self, config: ModuleConfig, attraction: AttractionConfig) -> None:
-        rot = UERotator(**config.rotation)
-        self.transform = UETransform(
+        rot = Rotator(**config.rotation)
+        self.transform = Transform(
             translation=np.array(config.registration_point_cm, dtype=float),
             rotation=rot,
         )
@@ -238,7 +228,7 @@ class FlowerModule:
 
 class Coordinator:
     """
-    Top-level orchestrator.  Mirrors AFlowerBedCoordinator::OnBlobDetectionResult.
+    Top-level orchestrator.
 
     Usage:
         coordinator = Coordinator.from_config(settings)
@@ -257,13 +247,13 @@ class Coordinator:
 
     def process_blobs(
         self,
-        camera_transform: UETransform,
+        camera_transform: Transform,
         blobs_3d: list,  # list[blob_tracker.Blob3D]
     ) -> list[MotorCommand]:
         """
-        Transform blobs from camera-local UE space to world space, then
-        dispatch to all modules.  Uses synthetic per-frame IDs so dwell and
-        inertia bonuses are unavailable on this path — prefer process_tracked_blobs.
+        Transform blobs from camera-local space to world space, then dispatch
+        to all modules.  Uses synthetic per-frame IDs so dwell and inertia
+        bonuses are unavailable on this path — prefer process_tracked_blobs.
         """
         from blob_stabilizer import TrackedBlob as TB
         from transforms import transform_position

--- a/ShowControl/FlowerBeds/main.py
+++ b/ShowControl/FlowerBeds/main.py
@@ -37,7 +37,7 @@ from flower_beds import (
     MotorCommand,
 )
 from flower_controller import FlowerController
-from transforms import UERotator, UETransform, transform_position
+from transforms import Rotator, Transform, transform_position
 
 log = logging.getLogger("flower_beds")
 
@@ -118,11 +118,10 @@ def run(args: argparse.Namespace) -> None:
     if not raw_cameras:
         log.error("No cameras defined in settings")
         sys.exit(1)
-    # Currently supporting one camera (same as the single-tracker UE setup)
     cam_cfg = parse_camera_config(raw_cameras[0])
-    camera_transform = UETransform(
+    camera_transform = Transform(
         translation=np.array(cam_cfg.pos_cm, dtype=float),
-        rotation=UERotator(**cam_cfg.rotation),
+        rotation=Rotator(**cam_cfg.rotation),
     )
 
     if args.mock:
@@ -196,7 +195,7 @@ def run(args: argparse.Namespace) -> None:
             if not _running[0]:
                 break
 
-            # Drive calibration state machine (mirrors OrbbecBlobTracker::OnFramesReceived)
+            # Drive calibration state machine
             if tracker.state == CalibrationState.NOT_CALIBRATED:
                 tracker.begin_calibration(calib_frames, frame.width, frame.height)
                 tracker.push_calibration_frame(frame)
@@ -278,7 +277,7 @@ def run_calibrate(args: argparse.Namespace) -> None:
     flowers can be rotated to a known reference orientation.
 
     All motors are held at --calibrate-yaw degrees (default 0) until Ctrl+C.
-    0° = forward (+X world axis), 90° = right (+Y), -90° = left.
+    0° = forward (+Y world axis), 90° = right (+X), -90° = left.
     """
     settings = load_settings(args.config)
     yaw = args.calibrate_yaw

--- a/ShowControl/FlowerBeds/settings.json
+++ b/ShowControl/FlowerBeds/settings.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "Python port config — mirrors FlowerBeds/Config/DefaultGame.ini",
   "calibration_frames": 60,
   "stabilizer": {
     "_comment": "Cross-frame blob ID tracking and EMA de-jittering",
@@ -27,8 +26,8 @@
   "modules": [
     {
       "registration_point_cm": [
-        -84,
         -40,
+        -84,
         0
       ],
       "rotation": {
@@ -40,8 +39,8 @@
         {
           "motor_id": 14,
           "pos_offset_cm": [
-            -30.0,
             40.0,
+            -30.0,
             0.0
           ],
           "rotation_offset": {
@@ -53,8 +52,8 @@
         {
           "motor_id": 22,
           "pos_offset_cm": [
-            -75.0,
             40.0,
+            -75.0,
             0.0
           ],
           "rotation_offset": {
@@ -66,8 +65,8 @@
         {
           "motor_id": 16,
           "pos_offset_cm": [
-            -25.0,
             100.0,
+            -25.0,
             0.0
           ],
           "rotation_offset": {
@@ -79,8 +78,8 @@
         {
           "motor_id": 6,
           "pos_offset_cm": [
-            -70.0,
             95.0,
+            -70.0,
             0.0
           ],
           "rotation_offset": {

--- a/ShowControl/FlowerBeds/transforms.py
+++ b/ShowControl/FlowerBeds/transforms.py
@@ -1,17 +1,26 @@
 """
-Minimal UE coordinate-system helpers.
+Coordinate-system helpers for the CommunityGarden show control.
 
-UE world space:
-  X = Forward
-  Y = Right
+World space (installation frame):
+  X = Right
+  Y = Forward (depth direction from the camera)
   Z = Up
   Units: centimetres
 
-Rotation convention (FRotator):
-  Pitch = rotation around Y axis
-  Yaw   = rotation around Z axis
-  Roll  = rotation around X axis
-  Application order: Roll first, then Pitch, then Yaw (intrinsic XYZ).
+This is a right-handed system and aligns naturally with the Orbbec depth
+camera's output axes (X=right, Y=down, Z=forward in camera space).
+
+Camera space (Orbbec native output):
+  X = Right
+  Y = Down
+  Z = Forward
+  Units: metres
+
+Rotation convention (Rotator):
+  Pitch = rotation around X axis (right); positive = nose up
+  Yaw   = rotation around Z axis (up);   positive = rotate from forward toward right
+  Roll  = rotation around Y axis (forward)
+  Application order: Roll first, then Pitch, then Yaw (intrinsic YXZ).
 """
 
 from __future__ import annotations
@@ -23,29 +32,29 @@ from scipy.spatial.transform import Rotation
 
 
 @dataclass
-class UERotator:
+class Rotator:
     pitch: float = 0.0
     yaw: float = 0.0
     roll: float = 0.0
 
 
 @dataclass
-class UETransform:
+class Transform:
     translation: np.ndarray  # shape (3,), centimetres
-    rotation: UERotator
+    rotation: Rotator
 
 
-def rotator_to_matrix(r: UERotator) -> np.ndarray:
-    """Return a 3×3 rotation matrix for a UE FRotator."""
-    # Intrinsic XYZ ≡ extrinsic ZYX.
-    # UE pitch is left-handed (positive = nose up rotates +X toward +Z), which
-    # is the opposite sense to scipy's right-handed R_y, so pitch is negated.
-    rot = Rotation.from_euler("XYZ", [r.roll, -r.pitch, r.yaw], degrees=True)
+def rotator_to_matrix(r: Rotator) -> np.ndarray:
+    """Return a 3×3 rotation matrix for a Rotator."""
+    # Intrinsic yxz: roll around Y, then pitch around body X, then yaw around body Z.
+    # Yaw is negated because positive yaw (from +Y toward +X) is clockwise
+    # when viewed from +Z, which is -R_Z in scipy's right-handed convention.
+    rot = Rotation.from_euler("yxz", [r.roll, r.pitch, -r.yaw], degrees=True)
     return rot.as_matrix()
 
 
-def transform_position(transform: UETransform, point: np.ndarray) -> np.ndarray:
-    """Apply a UE transform to a point (no scale)."""
+def transform_position(transform: Transform, point: np.ndarray) -> np.ndarray:
+    """Apply a Transform to a point (no scale)."""
     m = rotator_to_matrix(transform.rotation)
     return m @ point + transform.translation
 
@@ -55,7 +64,8 @@ def look_yaw_degrees(from_pos: np.ndarray, to_pos: np.ndarray) -> float:
     Return the yaw angle (degrees) that faces from_pos toward to_pos,
     ignoring elevation (projects onto the XY plane).
 
-    Matches FBlobTracker::GetLookRotation / FlowerCluster::UpdateClusterTargets.
+    Yaw = 0 means facing +Y (forward).
+    Positive yaw rotates from +Y (forward) toward +X (right).
     """
     direction = to_pos - from_pos
     direction = direction.copy()
@@ -64,5 +74,5 @@ def look_yaw_degrees(from_pos: np.ndarray, to_pos: np.ndarray) -> float:
     if norm < 1e-6:
         return 0.0
     direction /= norm
-    # UE yaw: atan2(Y, X)  (rotation from X-forward toward Y-right)
-    return float(np.degrees(np.arctan2(direction[1], direction[0])))
+    # atan2(X, Y): angle from +Y (forward) toward +X (right)
+    return float(np.degrees(np.arctan2(direction[0], direction[1])))

--- a/ShowControl/FlowerBeds/visualizer.py
+++ b/ShowControl/FlowerBeds/visualizer.py
@@ -94,11 +94,11 @@ function draw(state) {
   const scaleY = (H - pad*2) / (maxY - minY || 1);
   const scale  = Math.min(scaleX, scaleY);
 
-  // UE world → canvas  (X=forward→down, Y=right→right)
+  // world → canvas  (X=right, Y=forward→down)
   function toCanvas(wx, wy) {
     return [
-      pad + (wy - minY) * scale,            // world Y → canvas X (right)
-      pad + (wx - minX) * scale,            // world X → canvas Y (down)
+      pad + (wx - minX) * scale,            // world X (right) → canvas X (right)
+      pad + (wy - minY) * scale,            // world Y (forward) → canvas Y (down)
     ];
   }
 
@@ -124,24 +124,24 @@ function draw(state) {
 
   // ---- axis indicator (fixed top-left corner) ----
   const axOriginX = 52, axOriginY = 52, axLen = 36;
-  // +X axis: world X → canvas down (+Y)
+  // +X axis: world X (right) → canvas right
   ctx.strokeStyle = '#e05252'; ctx.lineWidth = 2;
-  ctx.beginPath(); ctx.moveTo(axOriginX, axOriginY); ctx.lineTo(axOriginX, axOriginY + axLen); ctx.stroke();
-  // arrowhead
-  ctx.beginPath(); ctx.moveTo(axOriginX, axOriginY + axLen);
-  ctx.lineTo(axOriginX - 4, axOriginY + axLen - 8); ctx.lineTo(axOriginX + 4, axOriginY + axLen - 8); ctx.closePath();
-  ctx.fillStyle = '#e05252'; ctx.fill();
-  ctx.fillStyle = '#e05252'; ctx.font = 'bold 10px monospace'; ctx.textAlign = 'center';
-  ctx.fillText('+X (fwd)', axOriginX, axOriginY + axLen + 12);
-  // +Y axis: world Y → canvas right (+X)
-  ctx.strokeStyle = '#52e07a'; ctx.lineWidth = 2;
   ctx.beginPath(); ctx.moveTo(axOriginX, axOriginY); ctx.lineTo(axOriginX + axLen, axOriginY); ctx.stroke();
   // arrowhead
   ctx.beginPath(); ctx.moveTo(axOriginX + axLen, axOriginY);
   ctx.lineTo(axOriginX + axLen - 8, axOriginY - 4); ctx.lineTo(axOriginX + axLen - 8, axOriginY + 4); ctx.closePath();
+  ctx.fillStyle = '#e05252'; ctx.fill();
+  ctx.fillStyle = '#e05252'; ctx.font = 'bold 10px monospace'; ctx.textAlign = 'left';
+  ctx.fillText('+X (right)', axOriginX + axLen + 4, axOriginY + 4);
+  // +Y axis: world Y (forward) → canvas down
+  ctx.strokeStyle = '#52e07a'; ctx.lineWidth = 2;
+  ctx.beginPath(); ctx.moveTo(axOriginX, axOriginY); ctx.lineTo(axOriginX, axOriginY + axLen); ctx.stroke();
+  // arrowhead
+  ctx.beginPath(); ctx.moveTo(axOriginX, axOriginY + axLen);
+  ctx.lineTo(axOriginX - 4, axOriginY + axLen - 8); ctx.lineTo(axOriginX + 4, axOriginY + axLen - 8); ctx.closePath();
   ctx.fillStyle = '#52e07a'; ctx.fill();
-  ctx.fillStyle = '#52e07a'; ctx.font = 'bold 10px monospace'; ctx.textAlign = 'left';
-  ctx.fillText('+Y (right)', axOriginX + axLen + 5, axOriginY + 4);
+  ctx.fillStyle = '#52e07a'; ctx.font = 'bold 10px monospace'; ctx.textAlign = 'center';
+  ctx.fillText('+Y (fwd)', axOriginX, axOriginY + axLen + 12);
 
 
   // ---- cameras ----


### PR DESCRIPTION
World space is now X=right, Y=forward, Z=up (centimetres) — a right-handed
system that aligns directly with the Orbbec camera's native output axes
(X=right, Y=down, Z=forward). Previously the world space used a left-handed
UE-style convention (X=forward, Y=right, Z=up) that carried over from an
earlier C++ Unreal Engine implementation.

Changes:
- transforms.py: rename UETransform→Transform, UERotator→Rotator; update
  rotation matrix formula from extrinsic XYZ to intrinsic yxz (pitch no
  longer negated, yaw negated to match right-handed convention); update
  look_yaw_degrees to atan2(X, Y) for the new axis layout; full docstring
  rewrite describing the new coordinate system without UE terminology
- blob_tracker.py: update world_pos_cm() to map cam_X→world_X, cam_Z→world_Y
  (previously cam_Z→world_X, cam_X→world_Y); update world_half_extents_cm()
  to match; remove "Port of IIVision FBlobTracker" from docstring
- flower_beds.py: update imports (Rotator/Transform), remove all C++ mirror
  comments (AFlower*, FFlower*), update FlowerModule/Coordinator docstrings
- main.py: update imports, remove "single-tracker UE setup" comment, fix
  calibrate-yaw axis description to match new convention
- visualizer.py: swap toCanvas() so world X (right)→canvas X and world Y
  (forward)→canvas Y (down); update axis indicator arrows and labels
- settings.json: remap all position vectors (swap X/Y to match new axes),
  remove C++ DefaultGame.ini comment
- CLAUDE.md: full rewrite of coordinate system docs; remove "former C++ struct"
  table; remove all UE/FRotator/AFlower* references; update settings example

https://claude.ai/code/session_01PehS2t7mK5G8P5eZQsKdgy