### PR TITLE
Add GlowPanel prototype docs and Pico firmware

### DIFF
--- a/Prototypes/GlowPanels/01_SideLit/README.md
+++ b/Prototypes/GlowPanels/01_SideLit/README.md
@@ -1,0 +1,137 @@
+# Prototype 01 — Side-Lit Clear Acrylic
+
+Light enters the acrylic from one edge and propagates internally via total internal reflection. The painted mycelium strands act as scattering points that break TIR and let light escape — so only the strand shapes glow. Strands far from the LED edge glow less intensely, giving a free, natural gradient.
+
+---
+
+## How It Works
+
+```
+  ┌──────────────────────────────────┐
+  │   ░░░ painted opaque surface ░░░ │  ← black acrylic paint
+  │                                  │
+  │  ══ strand (clear, unpainted) ══ │  ← light scatters upward here
+  │                                  │
+  │   ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ │
+  └──────────────────────────────────┘
+  ▲ LED strip along bottom edge
+  Light travels right → gradient falls off naturally with distance
+```
+
+The gradient is physical: no software needed to create it. Mode B (breathing) adds organic animation on top.
+
+---
+
+## Materials
+
+### Acrylic & Finishing
+| Item | Spec | Notes |
+|---|---|---|
+| Clear acrylic sheet | 1/8" (3 mm), 30 × 20 cm | You already have this |
+| Flat black acrylic paint | Liquitex Basics or similar | Matt finish prevents reflections |
+| Small artist brush + sponge roller | — | Roller gives even opaque coverage |
+| Mycelium stencil or frisket film | — | Mask strands before painting |
+| Isopropyl alcohol, 70%+ | — | Degrease acrylic before painting |
+
+### LED Strip & Electronics
+| Item | Spec | Where to get |
+|---|---|---|
+| SK6812 RGBW strip | 60 LED/m, 5 V, white PCB preferred | Adafruit #2842 or BTF-Lighting |
+| Strip segment length | 30 cm (≈ 18 LEDs) | Cut at solder pads |
+| Raspberry Pi Pico | any revision | You already have this |
+| 5 V / 1 A power supply | USB-A brick or bench supply | |
+| 300 Ω resistor | 1/4 W | In-line on data wire |
+| 470 µF capacitor | 6.3 V+ electrolytic | Across 5 V and GND at strip |
+| Micro USB cable | — | For Pico programming |
+| Hookup wire | 22–24 AWG stranded | ~30 cm of each colour |
+| Heat-shrink tubing | 3 mm | Insulate solder joints |
+
+### Enclosure & Mounting
+| Item | Spec | Notes |
+|---|---|---|
+| Aluminium U-channel | 3/8" or 10 mm inner width, 30 cm | Holds strip + acrylic edge. Hardware store or online. |
+| OR 3D-printed edge channel | See note below | PLA, black |
+| Foam tape, 1 mm | — | Cushions acrylic in channel, diffuses LED hotspots |
+| Black gaffer tape | — | Covers back of strip, seals channel ends |
+| M3 screws + standoffs | 4× 10 mm | Mount panel to a test rig or frame |
+
+> **U-channel alternative:** A folded strip of black craft foam taped along the edge works fine for a quick prototype. The goal is just to hold the strip flush against the acrylic edge and block light leakage from the sides.
+
+---
+
+## Build Steps
+
+### 1. Cut and Degrease the Acrylic
+- Cut acrylic to 30 × 20 cm if not already sized.
+- Wipe all surfaces with IPA. Let dry 2 min.
+- Leave the protective film on the back face during painting.
+
+### 2. Mask the Mycelium Strands
+- Sketch your strand pattern lightly in pencil on the **top surface**.
+- Apply frisket/masking film and cut out the strand shapes with a craft knife, OR
+- Use painters tape to rough-mask the strands (lower detail, easier).
+- The unmasked areas will remain clear and glow.
+
+### 3. Paint the Panel
+- Apply 2–3 thin coats of flat black acrylic paint to the top surface using a sponge roller.
+- Let each coat dry fully (15–20 min).
+- Check over a light source: zero bleed-through between strands means you have enough coats.
+- Carefully peel the masking once the final coat is dry.
+- Peel the protective film from the back face.
+
+### 4. Prepare the LED Strip
+- Cut a 30 cm segment of SK6812 strip at the solder pads.
+- Solder three wires: 5 V (red), GND (black), DATA (yellow/green).
+- Solder the 300 Ω resistor in-line on the DATA wire, close to the strip end.
+- Attach the 470 µF cap across 5 V/GND at the strip input solder pads (negative stripe = GND).
+- Cover all solder joints with heat-shrink.
+
+### 5. Mount Strip in Channel
+- Stick the LED strip inside the U-channel with its self-adhesive backing, LEDs facing inward (toward where the acrylic edge will sit).
+- Run a thin strip of 1 mm foam tape on the LED face — this presses the strip lightly against the acrylic edge and diffuses point-source hotspots.
+- Slide the bottom edge of the acrylic into the channel. The acrylic edge should sit flush against (or 1–2 mm from) the LED faces.
+- Seal the ends with black gaffer tape to prevent light escaping sideways.
+
+### 6. Wire the Pico
+
+```
+SK6812 strip          Pico (MicroPython)
+─────────────         ──────────────────
+5 V           ──┬──→  VBUS  (pin 40)       [or external 5 V]
+                │
+470 µF cap ─ GND ──→  GND   (pin 38)
+DATA      →[300Ω]──→  GP0   (pin 1)
+```
+
+> For strips longer than 30 LEDs or brighter colours, feed 5 V to the strip **directly from your PSU**, not through the Pico's VBUS. Connect GND of the PSU to Pico GND.
+
+### 7. Load Firmware
+1. Flash Pico with MicroPython if not already done (download UF2 from micropython.org, drag to RPI-RP2 drive).
+2. Copy `../firmware/panel_gradient.py` to the Pico as `main.py` using Thonny or `mpremote`.
+3. Set `NUM_LEDS = 18`, `MODE = "A"` for the first test.
+4. Power up — strands should glow, bright at the bottom edge, fading toward the top.
+5. Switch to `MODE = "B"` and re-run to compare the breathing effect.
+
+---
+
+## What to Observe
+
+Stand 1–3 m back and note:
+
+- **Gradient evenness** — does the falloff read as intentional or patchy?
+- **Hotspot visibility** — can you see individual LED dots through the acrylic edge? (Foam tape should suppress this.)
+- **Strand definition** — do the mycelium shapes read crisply or do they bloom/blur?
+- **Colour** — adjust `COLOR_WARM` vs `COLOR_COOL` in the firmware to taste.
+- **Mode A vs B** — static vs breathing at viewing distance.
+
+---
+
+## Tuning Tips
+
+| Problem | Fix |
+|---|---|
+| Hotspots at edge | Add more foam tape thickness, or sand the bottom acrylic edge with 220-grit |
+| Strands near top too dim | Increase `GRADIENT_MIN` in firmware, or add a second strip on the top edge |
+| Paint bleeding under mask | Use thinner coats; press mask edges firmly before painting |
+| Flickering | Add or increase the capacitor; check resistor on data line |
+| Wrong colours | SK6812 byte order is GRBW on wire — see note in firmware |

--- a/Prototypes/GlowPanels/02_BackLit_Frosted/README.md
+++ b/Prototypes/GlowPanels/02_BackLit_Frosted/README.md
@@ -1,0 +1,169 @@
+# Prototype 02 — Back-Lit Frosted Acrylic
+
+SK6812 strips sit behind the acrylic in a shallow light box. The frosted face of the acrylic diffuses individual LED hotspots into a soft field. Opaque black paint on the front masks everything except the mycelium strands — those stay clear and glow wherever the light box illuminates them. The gradient is entirely software-driven, giving full control but requiring more LEDs than the side-lit approach.
+
+---
+
+## How It Works
+
+```
+  Viewer
+    ↑
+  ┌─────────────────────────────────┐
+  │ ░░░ black paint (front face) ░░ │  ← opaque mask
+  │ ══════ clear strand ══════════  │  ← glow escapes here
+  │ ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ │
+  ├─────────────────────────────────┤  ← 1/8" frosted acrylic
+  │   ≈ 3–5 cm air gap             │  ← lets light spread between LEDs
+  │  ▓ SK6812 strip  ▓  strip  ▓   │  ← rows of strip on white base
+  └─────────────────────────────────┘  ← white-painted MDF or foam-core backing
+```
+
+The air gap between the strips and the acrylic is critical — too shallow and you see stripe banding; too deep and the box gets bulky. 3–5 cm is the sweet spot for a 30 × 20 cm panel.
+
+---
+
+## Materials
+
+### Acrylic & Finishing
+| Item | Spec | Notes |
+|---|---|---|
+| Clear acrylic sheet | 1/8" (3 mm), 30 × 20 cm | You already have this |
+| Frosted glass spray | Rust-Oleum 1903830 or similar | 2–3 light coats on **one face** — this becomes the back face |
+| OR 220-grit sandpaper | — | Hand-sand one face to frost it; cheaper, slightly less even |
+| Flat black acrylic paint | Liquitex Basics or similar | Applied to the **front face** |
+| Frisket film or masking tape | — | Mask mycelium strands before painting |
+| Isopropyl alcohol, 70%+ | — | Degrease before any coating |
+
+> **Frosting tip:** Spray in thin passes 30 cm away. Two coats = light diffusion; three coats = heavier diffusion. More diffusion = softer glow but more light loss. Start light and add coats.
+
+### LED Strip & Electronics
+| Item | Spec | Where to get |
+|---|---|---|
+| SK6812 RGBW strip | 60 LED/m, 5 V | Adafruit #2842 or BTF-Lighting |
+| Strip length | 90 cm total (3 × 30 cm rows) | Cut at solder pads |
+| Raspberry Pi Pico | any revision | You already have this |
+| 5 V / 2 A power supply | USB-A brick or bench PSU | 3 rows at moderate brightness needs ~1.5 A |
+| 300 Ω resistor | 1/4 W | On data line |
+| 470 µF capacitor | 6.3 V+ electrolytic | Across 5 V/GND at strip input |
+| Micro USB cable | — | Pico programming |
+| Hookup wire | 22–24 AWG stranded | ~60 cm each colour for daisy-chaining rows |
+| Heat-shrink | 3 mm | |
+
+### Light Box
+| Item | Spec | Notes |
+|---|---|---|
+| Foam-core board | 5 mm, black exterior | Sides and back of the box. Craft stores, ~A1 sheet |
+| OR MDF sheet | 6 mm | Sturdier; paint interior white |
+| White acrylic paint or white foam-core | — | Coat the interior for maximum reflectivity |
+| Hot glue gun + sticks | — | Assemble the box |
+| Black gaffer tape | — | Seal seams, no light leakage |
+| M3 screws + standoffs | 4× | Mount acrylic to box face |
+| Self-adhesive hook-and-loop | — | Optional: keep acrylic removable for adjustments |
+
+---
+
+## Build Steps
+
+### 1. Frost the Back Face of the Acrylic
+Keep the protective film on the **front face**. Work on the bare back face.
+
+**Spray method:**
+- Lay the acrylic flat, back face up, outdoors or in ventilated space.
+- Apply 2 light coats of frosted glass spray, 30 cm distance, sweeping passes.
+- Wait 10 min between coats. Let cure 30 min before handling.
+
+**Sand method:**
+- Wet-sand the back face with 220-grit in circular motions.
+- Rinse, dry, check diffusion by shining a phone flashlight through. Add more sanding if uneven.
+
+### 2. Mask and Paint the Front Face
+- Peel the protective film off the front face.
+- Wipe with IPA.
+- Lay on masking film and cut out mycelium strand shapes.
+- Apply 2–3 coats of flat black paint with a sponge roller.
+- Peel masking once fully dry. The strand areas should be completely clear acrylic.
+
+### 3. Build the Light Box
+
+Cut foam-core or MDF:
+- **Back panel:** 30 × 20 cm
+- **Side rails:** 2× at 30 × 4 cm (long sides)
+- **End rails:** 2× at 20 × 4 cm (short sides)
+
+Assemble with hot glue (foam-core) or wood glue + staples (MDF). The interior depth is 4 cm — enough air gap for light to spread.
+
+Paint or line the interior with white. Even a sheet of white paper glued to the back panel works.
+
+### 4. Mount LED Strips Inside the Box
+
+Three rows of 30 cm strip, evenly spaced vertically (top, middle, bottom of the 20 cm height, so roughly at 3 cm, 10 cm, 17 cm from top).
+
+- Stick strips to the white back panel with their self-adhesive backing.
+- Wire them in series (DATA out of row 1 → DATA in of row 2 → row 3).
+- Power (5 V / GND) can be tapped from the first strip's input pads and run to each row separately (parallel power, series data).
+
+```
+ Pico GP0 → [300Ω] → Row1 DIN
+                       Row1 DOUT → Row2 DIN
+                                    Row2 DOUT → Row3 DIN
+
+ 5V PSU ──────────→ Row1 5V   Row2 5V   Row3 5V  (parallel)
+ GND   ──────────→ Row1 GND  Row2 GND  Row3 GND  (parallel)
+```
+
+Total LED count: 3 rows × 18 LEDs = 54 LEDs. Set `NUM_LEDS = 54` in firmware.
+
+### 5. Wire the Pico
+
+```
+SK6812 Row 1          Pico
+─────────────         ──────────────────
+5 V   ────────────→  VBUS  (pin 40)  [only for < 300 mA; prefer external PSU]
+GND   ──────────┬──→  GND   (pin 38)
+DATA  →[300Ω]───┘──→  GP0   (pin 1)
+470µF cap across 5V/GND at strip input
+```
+
+> Feed 5 V to all three strip rows from the PSU directly. Connect PSU GND to Pico GND. Do not power 54 LEDs through the Pico VBUS pin.
+
+### 6. Attach the Acrylic
+
+Mount the painted acrylic panel (frosted face toward interior) to the open face of the box:
+- Use 4× M3 standoffs at corners so the acrylic is removable for adjustments.
+- Or use hook-and-loop strips along all four edges for a tool-free swap.
+- Seal any remaining gaps with black gaffer tape — any light leakage around the edges will wash out the strand effect.
+
+### 7. Load Firmware
+
+1. Flash Pico with MicroPython if not already done.
+2. Copy `../firmware/panel_gradient.py` to the Pico as `main.py`.
+3. Set `NUM_LEDS = 54`, `MODE = "A"` for first test.
+4. Power up — strands should glow with a gradient running top-to-bottom.
+5. Switch to `MODE = "B"` and re-run for the breathing effect.
+
+---
+
+## What to Observe
+
+Stand 1–3 m back and note:
+
+- **Banding** — can you see three distinct bright rows? (Increase air gap or add more frosting coats.)
+- **Gradient evenness** — does the software gradient look smooth across the full panel?
+- **Strand definition** — do edges of strands read crisply? (Too much frosting = softer edges.)
+- **Brightness vs diffusion trade-off** — note how each extra coat of frost reduces peak strand brightness.
+- **Mode A vs Mode B** at viewing distance.
+- **Compare to Prototype 01** — which strand aesthetic reads better?
+
+---
+
+## Tuning Tips
+
+| Problem | Fix |
+|---|---|
+| Visible strip banding | Increase air gap (deeper box) or add frosting coats |
+| Strands look blurry | Reduce frosting (sand less / fewer spray coats) |
+| Not bright enough | Increase `BRIGHTNESS` in firmware; check PSU amperage |
+| Gradient looks stepped | Ensure `NUM_LEDS` matches actual count; try `GRADIENT_MIN = 0.1` |
+| Paint adhesion poor on frosted face | Lightly wipe with IPA before painting (don't re-sand) |
+| Light leaking around box edges | Gaffer tape all seams; check standoff gaps |

--- a/Prototypes/GlowPanels/README.md
+++ b/Prototypes/GlowPanels/README.md
@@ -1,0 +1,58 @@
+# Glow Panel Prototypes
+
+Two prototype approaches for mycelium-strand glow panels using SK6812 RGBW strips and 1/8" clear acrylic. Both panels are painted opaque, leaving only the mycelium strand shapes unmasked so light escapes only through those paths.
+
+The firmware supports two gradient modes — run both on each panel and compare before committing to a method.
+
+---
+
+## Prototypes
+
+| | [01 — Side-Lit Clear Acrylic](01_SideLit/README.md) | [02 — Back-Lit Frosted Acrylic](02_BackLit_Frosted/README.md) |
+|---|---|---|
+| **Light path** | Enters the acrylic edge, travels internally, exits through unmasked strand surfaces | Shines through the full panel face, frosting diffuses hotspots |
+| **Acrylic prep** | None — use the clear 1/8" sheet as-is | Sand or film-frost one face before painting |
+| **LED count (30×20cm proto)** | ~18 LEDs (single edge strip) | ~36–54 LEDs (2–3 rows behind panel) |
+| **Gradient character** | Natural distance falloff from the lit edge; strands near the edge glow brightest | Uniform field; gradient is entirely software-controlled |
+| **Hotspot risk** | Low — internal reflection softens point sources | Moderate — needs enough air gap and diffusion |
+| **Paint masking side** | Top surface (the face you see) | Front face (same side as viewer) |
+| **Best for** | Dramatic, directional, low-power | Even, controllable, full-panel coverage |
+
+---
+
+## Gradient Methods to Compare
+
+Both panels run the same firmware (`firmware/panel_gradient.py`). Change `MODE` at the top of the file:
+
+| Mode | Name | Character |
+|---|---|---|
+| `"A"` | Static gradient | Fixed brightness falloff from one end of the strip to the other. Calm, architectural. |
+| `"B"` | Breathing gradient | Each LED pulses on a slightly offset sine wave. Organic, bioluminescent. |
+
+Test both modes on both panels and note which combination reads best at festival viewing distance (~1–3 m).
+
+---
+
+## Shared Hardware
+
+- Raspberry Pi Pico (MicroPython firmware)
+- SK6812 RGBW strip, 60 LED/m density
+- 5 V power supply (1 A covers up to ~60 LEDs at moderate brightness)
+- Micro USB cable for flashing
+- 300–470 Ω resistor on data line (prevents ringing)
+- Small capacitor, 100–1000 µF across 5 V/GND at strip input (prevents voltage spike on power-on)
+
+---
+
+## Folder Layout
+
+```
+Prototypes/GlowPanels/
+├── README.md                    ← you are here
+├── 01_SideLit/
+│   └── README.md                ← materials, build steps, wiring
+├── 02_BackLit_Frosted/
+│   └── README.md                ← materials, build steps, wiring
+└── firmware/
+    └── panel_gradient.py        ← MicroPython for Pico, both gradient modes
+```

--- a/Prototypes/GlowPanels/firmware/panel_gradient.py
+++ b/Prototypes/GlowPanels/firmware/panel_gradient.py
@@ -1,0 +1,109 @@
+"""
+GlowPanel firmware — Raspberry Pi Pico (MicroPython)
+Controls SK6812 RGBW strips for mycelium glow panel prototypes.
+
+Two gradient modes — change MODE below, then save as main.py on the Pico.
+
+Wiring (see prototype READMEs for full diagrams):
+  SK6812 DATA  →  [300 Ω resistor]  →  GP0  (pin 1)
+  SK6812 5 V   →  VBUS (pin 40) or external 5 V PSU
+  SK6812 GND   →  GND  (pin 38)
+  470 µF cap across 5 V / GND at strip input
+
+SK6812 byte order on wire is G-R-B-W.
+set_pixel() accepts (r, g, b, w) and swaps internally.
+"""
+
+import time
+import math
+from machine import Pin
+import neopixel
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+
+NUM_LEDS  = 18      # 18 for side-lit single edge; 54 for back-lit 3-row box
+DATA_PIN  = 0       # GPIO number (GP0 = physical pin 1)
+
+# Global brightness multiplier 0.0–1.0.
+# Keep at 0.4–0.6 during prototyping to avoid blinding yourself.
+BRIGHTNESS = 0.5
+
+# RGBW base colour — (R, G, B, W) each 0–255.
+# COLOR_WARM: warm white-green tint, earthen/mycelium feel.
+# COLOR_COOL: cooler cyan-white, more bioluminescent.
+COLOR_WARM = (20,  60,  40, 180)
+COLOR_COOL = (10,  80,  80, 120)
+
+BASE_COLOR = COLOR_WARM
+
+# Mode:
+#   "A"  Static gradient — fixed brightness falloff from LED[0] to LED[N-1].
+#        Calm, architectural. No animation loop needed.
+#   "B"  Breathing gradient — per-LED sine wave with a phase offset between
+#        neighbours. Organic, bioluminescent pulse.
+MODE = "A"
+
+# ── Mode A settings ───────────────────────────────────────────────────────────
+# Gradient runs bright→dim from index 0 to NUM_LEDS-1.
+GRADIENT_BRIGHT = 1.0    # scale at the bright end (index 0)
+GRADIENT_DIM    = 0.05   # scale at the dim end  (last index)
+
+# ── Mode B settings ───────────────────────────────────────────────────────────
+BREATHE_SPEED      = 0.4    # full cycles per second (higher = faster pulse)
+BREATHE_PHASE_STEP = 0.25   # radian phase shift between adjacent LEDs
+#                             larger = more wave-like; 0 = whole strip in sync
+BREATHE_MIN        = 0.02   # floor brightness during trough (prevents full-off)
+
+# ─────────────────────────────────────────────────────────────────────────────
+
+_pin = Pin(DATA_PIN, Pin.OUT)
+# bpp=4 enables 4-byte (RGBW) mode. MicroPython writes bytes in the order
+# stored in the buffer, so we store them in SK6812 wire order (GRBW) manually.
+np = neopixel.NeoPixel(_pin, NUM_LEDS, bpp=4)
+
+
+def set_pixel(i, r, g, b, w, scale=1.0):
+    """Write one pixel with a per-call brightness scale applied on top of BRIGHTNESS."""
+    s = min(max(scale * BRIGHTNESS, 0.0), 1.0)
+    # SK6812 wire order is GRBW — swap r and g in the buffer.
+    np[i] = (int(g * s), int(r * s), int(b * s), int(w * s))
+
+
+def show_static_gradient():
+    """Mode A: pre-compute a fixed gradient and write once."""
+    r, g, b, w = BASE_COLOR
+    for i in range(NUM_LEDS):
+        t = i / max(NUM_LEDS - 1, 1)                          # 0.0 → 1.0
+        scale = GRADIENT_BRIGHT - t * (GRADIENT_BRIGHT - GRADIENT_DIM)
+        set_pixel(i, r, g, b, w, scale)
+    np.write()
+
+
+def show_breathing_gradient(t_sec):
+    """Mode B: animate per-LED sine wave with phase offset between neighbours."""
+    r, g, b, w = BASE_COLOR
+    for i in range(NUM_LEDS):
+        phase = t_sec * BREATHE_SPEED * 2.0 * math.pi + i * BREATHE_PHASE_STEP
+        factor = (math.sin(phase) + 1.0) * 0.5               # 0.0 – 1.0
+        scale = BREATHE_MIN + factor * (1.0 - BREATHE_MIN)
+        set_pixel(i, r, g, b, w, scale)
+    np.write()
+
+
+def main():
+    if MODE == "A":
+        show_static_gradient()
+        while True:
+            time.sleep(1)
+
+    elif MODE == "B":
+        while True:
+            t = time.ticks_ms() / 1000.0
+            show_breathing_gradient(t)
+            time.sleep_ms(30)           # ~33 fps is plenty for this effect
+
+    else:
+        raise ValueError(f"Unknown MODE {MODE!r} — set to 'A' or 'B'")
+
+
+main()


### PR DESCRIPTION
Two side-by-side prototype builds for mycelium strand glow panels:
  01_SideLit  — single SK6812 strip along acrylic edge, natural distance gradient
  02_BackLit_Frosted — strip rows behind frosted acrylic in a light box, software gradient

Shared MicroPython firmware (panel_gradient.py) supports two gradient modes:
  A = static brightness falloff, B = per-LED breathing sine wave

Each prototype includes full materials list, build steps, wiring diagram, and tuning tips.

https://claude.ai/code/session_01E5VjcKiw5UhA67J4qVwCFw