### PR TITLE
TreeHouse: implement branch controller firmware and Python driver

### DIFF
--- a/Firmware/TreeHouse_BranchController/TreeHouse_BranchController.ino
+++ b/Firmware/TreeHouse_BranchController/TreeHouse_BranchController.ino
@@ -1,0 +1,132 @@
+/*
+  TreeHouse Branch Controller
+  OpenRB-150 (SAMD21)
+
+  Reads JSON-lines from USB serial (115200 baud):
+      {"id": 1, "pos": 90.0}
+
+  Drives the target Dynamixel servo to the requested position.
+
+  Acknowledges each command:
+      {"id": 1, "ok": true}
+
+  Required libraries:
+    - Dynamixel2Arduino
+    - ArduinoJson (>= 6.x)
+*/
+
+#include <ArduinoJson.h>
+#include <Dynamixel2Arduino.h>
+
+// OpenRB-150 does not require a DIR control pin for Dynamixel.
+#define DXL_SERIAL  Serial1
+#define USB_SERIAL  Serial
+const int DXL_DIR_PIN = -1;
+
+Dynamixel2Arduino dxl(DXL_SERIAL, DXL_DIR_PIN);
+
+const float DXL_PROTOCOL_VERSION = 2.0f;
+
+#define MAX_BAUD 5
+const int32_t BAUD_RATES[MAX_BAUD] = {57600, 115200, 1000000, 2000000, 3000000};
+
+bool activeServos[DXL_BROADCAST_ID];
+
+String inputBuffer = "";
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+void setup() {
+  USB_SERIAL.begin(115200);
+  // Brief wait so the USB-CDC host can enumerate; non-blocking after 2 s.
+  unsigned long t = millis();
+  while (!USB_SERIAL && (millis() - t) < 2000);
+
+  scanForServos();
+  USB_SERIAL.println("Branch controller ready");
+}
+
+// ---------------------------------------------------------------------------
+// Main loop — non-blocking line accumulator
+// ---------------------------------------------------------------------------
+
+void loop() {
+  while (USB_SERIAL.available()) {
+    char c = (char)USB_SERIAL.read();
+    if (c == '\n') {
+      inputBuffer.trim();
+      if (inputBuffer.length() > 0) {
+        processLine(inputBuffer);
+      }
+      inputBuffer = "";
+    } else if (c != '\r') {
+      inputBuffer += c;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command handling
+// ---------------------------------------------------------------------------
+
+void processLine(const String& line) {
+  StaticJsonDocument<64> doc;
+  if (deserializeJson(doc, line) != DeserializationError::Ok) return;
+  if (!doc.containsKey("id") || !doc.containsKey("pos")) return;
+
+  int id = doc["id"];
+  float pos = doc["pos"];
+  setPosDeg((uint8_t)id, pos);
+
+  StaticJsonDocument<32> ack;
+  ack["id"] = id;
+  ack["ok"] = true;
+  serializeJson(ack, USB_SERIAL);
+  USB_SERIAL.println();
+}
+
+// ---------------------------------------------------------------------------
+// Servo helpers
+// ---------------------------------------------------------------------------
+
+void scanForServos() {
+  memset(activeServos, false, sizeof(activeServos));
+  dxl.setPortProtocolVersion(DXL_PROTOCOL_VERSION);
+
+  USB_SERIAL.print("Scanning for Dynamixel servos (protocol ");
+  USB_SERIAL.print(DXL_PROTOCOL_VERSION);
+  USB_SERIAL.println(")...");
+
+  for (uint8_t bi = 0; bi < MAX_BAUD; bi++) {
+    USB_SERIAL.print("  baud ");
+    USB_SERIAL.println(BAUD_RATES[bi]);
+    dxl.begin(BAUD_RATES[bi]);
+    bool foundAtThisBaud = false;
+
+    for (uint8_t id = 0; id < DXL_BROADCAST_ID; id++) {
+      if (!dxl.ping(id)) continue;
+      activeServos[id] = true;
+      foundAtThisBaud = true;
+
+      USB_SERIAL.print("  found ID ");
+      USB_SERIAL.print(id);
+      USB_SERIAL.print(", model ");
+      USB_SERIAL.println(dxl.getModelNumber(id));
+
+      dxl.torqueOff(id);
+      dxl.setOperatingMode(id, OP_EXTENDED_POSITION);
+      dxl.torqueOn(id);
+    }
+
+    if (foundAtThisBaud) break;
+  }
+}
+
+void setPosDeg(uint8_t id, float posDeg) {
+  if (!activeServos[id]) return;
+  dxl.writeControlTableItem(ControlTableItem::PROFILE_ACCELERATION, id, 1);
+  dxl.writeControlTableItem(ControlTableItem::PROFILE_VELOCITY, id, 50);
+  dxl.setGoalPosition(id, posDeg, UNIT_DEGREE);
+}

--- a/ShowControl/TreeHouse/branch_controller.py
+++ b/ShowControl/TreeHouse/branch_controller.py
@@ -1,0 +1,49 @@
+import json
+import logging
+
+import serial
+
+log = logging.getLogger("treehouse")
+
+
+class BranchController:
+    """
+    Sends servo position commands to the branch OpenRB-150 over USB serial.
+
+    Protocol — one newline-delimited JSON object per command:
+        {"id": <int>, "pos": <float>}
+
+    The controller acknowledges each command with:
+        {"id": <int>, "ok": true}
+
+    This driver is fire-and-forget: it does not wait for acknowledgements.
+    If the serial port is unavailable the driver logs a warning and silently
+    drops commands rather than crashing the loop.
+    """
+
+    def __init__(self, port: str, baud: int = 115200) -> None:
+        self._port = port
+        self._baud = baud
+        self._serial: serial.Serial | None = None
+
+    def connect(self) -> None:
+        try:
+            self._serial = serial.Serial(self._port, self._baud, timeout=1)
+            log.info("BranchController connected on %s @ %d baud", self._port, self._baud)
+        except serial.SerialException as e:
+            log.warning("BranchController not available (%s) — branch output disabled", e)
+
+    def set_position(self, motor_id: int, degrees: float) -> None:
+        if not self._serial or not self._serial.is_open:
+            return
+        line = json.dumps({"id": motor_id, "pos": round(degrees, 2)}) + "\n"
+        try:
+            self._serial.write(line.encode())
+        except serial.SerialException as e:
+            log.error("BranchController write error: %s — branch output suspended", e)
+            self._serial = None
+
+    def close(self) -> None:
+        if self._serial and self._serial.is_open:
+            self._serial.close()
+            log.info("BranchController disconnected")

--- a/ShowControl/TreeHouse/coordinator.py
+++ b/ShowControl/TreeHouse/coordinator.py
@@ -35,6 +35,28 @@ class PicoConfig:
 
 
 @dataclass
+class BranchMotorConfig:
+    id: int
+    min_pos: float = 0.0
+    max_pos: float = 90.0
+    recoil_pos: float = -20.0
+    weight_flowerbeds: float = 0.6
+    weight_captcha: float = 0.2
+    weight_pipes: float = 0.2
+
+
+@dataclass
+class BranchConfig:
+    port: str = "/dev/ttyACM1"
+    baud: int = 115200
+    motors: list[BranchMotorConfig] = None
+
+    def __post_init__(self) -> None:
+        if self.motors is None:
+            self.motors = []
+
+
+@dataclass
 class OSCConfig:
     listen_port: int = 9001
 
@@ -89,6 +111,11 @@ class TreehouseConfig:
     gable_back: GableWindowConfig
     dormer: DormerConfig
     porch_lights: PorchLightsConfig
+    branch: BranchConfig = None
+
+    def __post_init__(self) -> None:
+        if self.branch is None:
+            self.branch = BranchConfig()
 
 
 # ---------------------------------------------------------------------------
@@ -188,6 +215,25 @@ def load_config(path: str) -> TreehouseConfig:
         aftermath_duration=pl.get("aftermath_duration", 10.0),
     )
 
+    bc = raw.get("branch_controller", {})
+    branch_motors = [
+        BranchMotorConfig(
+            id=m["id"],
+            min_pos=m.get("min_pos", 0.0),
+            max_pos=m.get("max_pos", 90.0),
+            recoil_pos=m.get("recoil_pos", -20.0),
+            weight_flowerbeds=m.get("weights", {}).get("flowerbeds", 0.6),
+            weight_captcha=m.get("weights", {}).get("captcha", 0.2),
+            weight_pipes=m.get("weights", {}).get("pipes", 0.2),
+        )
+        for m in bc.get("motors", [])
+    ]
+    branch = BranchConfig(
+        port=bc.get("port", "/dev/ttyACM1"),
+        baud=bc.get("baud", 115200),
+        motors=branch_motors,
+    )
+
     return TreehouseConfig(
         pico=PicoConfig(
             port=pico_raw.get("port", "/dev/ttyACM0"),
@@ -207,6 +253,7 @@ def load_config(path: str) -> TreehouseConfig:
         gable_back=gable_back,
         dormer=dormer,
         porch_lights=porch_lights,
+        branch=branch,
     )
 
 
@@ -263,7 +310,7 @@ def build_displays(config: TreehouseConfig) -> list[Controllable]:
 class Coordinator:
     """Owns all Controllable instances, drives the frame loop, manages show state."""
 
-    def __init__(self, displays: list[Controllable]) -> None:
+    def __init__(self, displays: list[Controllable], branch_config: BranchConfig | None = None) -> None:
         self._displays: dict[str, Controllable] = {d.name: d for d in displays}
         self._led_displays: dict[str, LEDDisplay] = {
             d.name: d for d in displays if isinstance(d, LEDDisplay)
@@ -283,6 +330,8 @@ class Coordinator:
         self._flowerbeds_activity = 0.0
         self._captcha_intensity = 0.0
         self._pipes_activity = 0.0
+        self._branch_motors: list[BranchMotorConfig] = (branch_config.motors if branch_config else [])
+        self._branch_positions: list[tuple[int, float]] = []
 
     @property
     def brightness(self) -> float:
@@ -350,6 +399,27 @@ class Coordinator:
         self._captcha_blowup_pending = False
         for controllable in self._displays.values():
             controllable.update(dt, state)
+        self._update_branch_positions(state)
+
+    def _update_branch_positions(self, state: GardenState) -> None:
+        positions: list[tuple[int, float]] = []
+        for motor in self._branch_motors:
+            if state.captcha_blowup:
+                pos = motor.recoil_pos
+            else:
+                signal = (
+                    motor.weight_flowerbeds * state.flowerbeds_activity
+                    + motor.weight_captcha * state.captcha_intensity
+                    + motor.weight_pipes * state.pipes_activity
+                )
+                signal = max(0.0, min(1.0, signal))
+                pos = motor.min_pos + signal * (motor.max_pos - motor.min_pos)
+            positions.append((motor.id, pos))
+        self._branch_positions = positions
+
+    def get_branch_positions(self) -> list[tuple[int, float]]:
+        """Return (motor_id, degrees) pairs for the current frame."""
+        return list(self._branch_positions)
 
     def get_all_frames(self) -> list[ChannelFrame]:
         frames: list[ChannelFrame] = []

--- a/ShowControl/TreeHouse/main.py
+++ b/ShowControl/TreeHouse/main.py
@@ -15,6 +15,7 @@ import argparse
 import asyncio
 import logging
 
+from branch_controller import BranchController
 from coordinator import Coordinator, build_displays, load_config
 from osc_server import serve as serve_osc
 from pico_driver import PicoDriver
@@ -27,6 +28,7 @@ def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="TreeHouse show control")
     p.add_argument("--config", default="settings.json", help="Path to settings JSON")
     p.add_argument("--no-pico", action="store_true", help="Skip Pico connection (dev mode)")
+    p.add_argument("--no-branch", action="store_true", help="Skip branch controller connection (dev mode)")
     p.add_argument("--no-osc", action="store_true", help="Skip OSC listener")
     p.add_argument("--no-visualizer", action="store_true", help="Disable WebSocket visualizer server")
     p.add_argument("--visualizer-port", type=int, default=8766, metavar="N",
@@ -35,7 +37,12 @@ def parse_args() -> argparse.Namespace:
     return p.parse_args()
 
 
-async def _frame_loop(coordinator: Coordinator, driver: PicoDriver, fps: int) -> None:
+async def _frame_loop(
+    coordinator: Coordinator,
+    driver: PicoDriver,
+    branch: BranchController,
+    fps: int,
+) -> None:
     dt = 1.0 / fps
     loop = asyncio.get_running_loop()
     frame = 0
@@ -43,6 +50,8 @@ async def _frame_loop(coordinator: Coordinator, driver: PicoDriver, fps: int) ->
         t0 = loop.time()
         coordinator.update(dt)
         driver.send_frames(coordinator.get_all_frames(), coordinator.brightness)
+        for motor_id, degrees in coordinator.get_branch_positions():
+            branch.set_position(motor_id, degrees)
         frame += 1
         if frame % fps == 0:  # ~once per second
             await visualizer.broadcast_state(coordinator)
@@ -52,18 +61,23 @@ async def _frame_loop(coordinator: Coordinator, driver: PicoDriver, fps: int) ->
 async def _run(args: argparse.Namespace) -> None:
     config = load_config(args.config)
     displays = build_displays(config)
-    coordinator = Coordinator(displays)
+    coordinator = Coordinator(displays, branch_config=config.branch)
     coordinator._dim_level = config.show.dim_level
 
     driver = PicoDriver(config.pico.port, config.pico.baud)
     if not args.no_pico:
         driver.connect()
 
-    log.info("TreeHouse starting — %d displays", len(displays))
+    branch = BranchController(config.branch.port, config.branch.baud)
+    if not args.no_branch:
+        branch.connect()
+
+    log.info("TreeHouse starting — %d displays, %d branch motors",
+             len(displays), len(config.branch.motors))
     for name in coordinator.display_names:
         log.info("  • %s", name)
 
-    tasks = [asyncio.create_task(_frame_loop(coordinator, driver, config.show.fps))]
+    tasks = [asyncio.create_task(_frame_loop(coordinator, driver, branch, config.show.fps))]
     if not args.no_osc:
         tasks.append(asyncio.create_task(serve_osc(coordinator, config.osc.listen_port)))
     if not args.no_visualizer:
@@ -73,6 +87,7 @@ async def _run(args: argparse.Namespace) -> None:
         await asyncio.gather(*tasks)
     finally:
         driver.close()
+        branch.close()
 
 
 def main() -> None:

--- a/ShowControl/TreeHouse/settings.json
+++ b/ShowControl/TreeHouse/settings.json
@@ -90,5 +90,23 @@
     "led_count": 2,
     "blowup_duration": 3.0,
     "aftermath_duration": 10.0
+  },
+
+  "branch_controller": {
+    "port": "/dev/ttyACM1",
+    "baud": 115200,
+    "motors": [
+      {
+        "id": 1,
+        "min_pos": 0.0,
+        "max_pos": 90.0,
+        "recoil_pos": -20.0,
+        "weights": {
+          "flowerbeds": 0.6,
+          "captcha": 0.2,
+          "pipes": 0.2
+        }
+      }
+    ]
   }
 }

--- a/ShowControl/TreeHouse/test_branch_positions.py
+++ b/ShowControl/TreeHouse/test_branch_positions.py
@@ -1,0 +1,76 @@
+"""Tests for Coordinator._update_branch_positions — position math only, no hardware."""
+import pytest
+
+from coordinator import BranchConfig, BranchMotorConfig, Coordinator
+from displays import GardenState
+
+
+def _coord(*motors: BranchMotorConfig) -> Coordinator:
+    return Coordinator([], branch_config=BranchConfig(motors=list(motors)))
+
+
+def _positions(coord: Coordinator, **state_kwargs) -> list[tuple[int, float]]:
+    state = GardenState(**state_kwargs)
+    coord._update_branch_positions(state)
+    return coord.get_branch_positions()
+
+
+def test_all_signals_zero_gives_min_pos():
+    motor = BranchMotorConfig(id=1, min_pos=10.0, max_pos=90.0)
+    assert _positions(_coord(motor)) == [(1, 10.0)]
+
+
+def test_all_signals_full_gives_max_pos():
+    motor = BranchMotorConfig(
+        id=1, min_pos=0.0, max_pos=90.0,
+        weight_flowerbeds=1.0, weight_captcha=0.0, weight_pipes=0.0,
+    )
+    assert _positions(_coord(motor), flowerbeds_activity=1.0) == [(1, 90.0)]
+
+
+def test_signal_clamped_when_weights_exceed_one():
+    # Weights sum to 3.0; with all signals at 1.0 the raw sum is 3.0, must clamp to 1.0 → max_pos.
+    motor = BranchMotorConfig(
+        id=1, min_pos=0.0, max_pos=90.0,
+        weight_flowerbeds=1.0, weight_captcha=1.0, weight_pipes=1.0,
+    )
+    result = _positions(_coord(motor), flowerbeds_activity=1.0, captcha_intensity=1.0, pipes_activity=1.0)
+    assert result == [(1, 90.0)]
+
+
+def test_captcha_blowup_overrides_to_recoil():
+    motor = BranchMotorConfig(id=1, min_pos=0.0, max_pos=90.0, recoil_pos=-20.0)
+    result = _positions(
+        _coord(motor),
+        captcha_blowup=True,
+        flowerbeds_activity=1.0, captcha_intensity=1.0, pipes_activity=1.0,
+    )
+    assert result == [(1, -20.0)]
+
+
+def test_partial_signal_interpolates():
+    motor = BranchMotorConfig(
+        id=1, min_pos=0.0, max_pos=100.0,
+        weight_flowerbeds=1.0, weight_captcha=0.0, weight_pipes=0.0,
+    )
+    assert _positions(_coord(motor), flowerbeds_activity=0.5) == [(1, 50.0)]
+
+
+def test_multiple_motors_computed_independently():
+    motor_a = BranchMotorConfig(
+        id=1, min_pos=0.0, max_pos=90.0,
+        weight_flowerbeds=1.0, weight_captcha=0.0, weight_pipes=0.0,
+    )
+    motor_b = BranchMotorConfig(
+        id=2, min_pos=10.0, max_pos=50.0,
+        weight_flowerbeds=0.0, weight_captcha=1.0, weight_pipes=0.0,
+    )
+    result = _positions(_coord(motor_a, motor_b), flowerbeds_activity=1.0, captcha_intensity=0.5)
+    assert result[0] == (1, 90.0)
+    assert result[1] == (2, 30.0)  # 10 + 0.5 * 40
+
+
+def test_no_motors_gives_empty_list():
+    coord = Coordinator([], branch_config=BranchConfig(motors=[]))
+    result = _positions(coord, flowerbeds_activity=1.0)
+    assert result == []

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = ShowControl IIVision


### PR DESCRIPTION
Closes #26

Implements the full actuator path for TreeHouse branches per ADR-0005 (USB serial JSON-lines) and ADR-0008 (GardenState weighted-blend personality).

**Firmware (`Firmware/TreeHouse_BranchController/`)**
- OpenRB-150 sketch with non-blocking USB serial line accumulator
- Parses `{"id": N, "pos": F}` JSON-lines, drives Dynamixel, acknowledges `{"id": N, "ok": true}`
- Servo scan mirrors FlowerBeds firmware; requires ArduinoJson >=6.x and Dynamixel2Arduino

**Python driver (`ShowControl/TreeHouse/branch_controller.py`)**
- `BranchController` class following the PicoDriver fire-and-forget pattern
- `set_position(motor_id, degrees)` over USB serial JSON-lines

**Wired into Coordinator**
- `BranchMotorConfig` / `BranchConfig` dataclasses, loaded from `settings.json`
- Weighted GardenState blend per ADR-0008: flowerbeds 0.6 / captcha 0.2 / pipes 0.2
- `captcha_blowup` fires `recoil_pos` override
- Frame loop calls `branch.set_position()` for each motor every tick

Generated with [Claude Code](https://claude.ai/code)