### PR TITLE
Add systemd service files and process supervisor for all show-control elements

### DIFF
--- a/ShowControl/Dashboard/deploy/dashboard.service
+++ b/ShowControl/Dashboard/deploy/dashboard.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=CommunityGarden Show Dashboard
+After=network.target
+Documentation=https://github.com/Impractical-Instruments/CommunityGarden/blob/main/docs/operations.md
+
+[Service]
+WorkingDirectory=/home/pi/CommunityGarden/ShowControl/Dashboard
+ExecStart=/usr/bin/python3 serve.py 9000
+Restart=always
+RestartSec=5
+User=pi
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=cg-dashboard
+
+[Install]
+WantedBy=multi-user.target

--- a/ShowControl/Dashboard/deploy/install.sh
+++ b/ShowControl/Dashboard/deploy/install.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# install.sh — set up the show Dashboard as an auto-starting systemd service.
+# Run once after cloning the repo:
+#   cd ShowControl/Dashboard/deploy
+#   sudo bash install.sh
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+APP_DIR="$REPO_ROOT/ShowControl/Dashboard"
+SERVICE_USER="${SUDO_USER:-pi}"
+
+echo "=== Dashboard install ==="
+echo "App dir: $APP_DIR"
+echo "User:    $SERVICE_USER"
+echo ""
+
+# ── Install service file ───────────────────────────────────────────────────────
+echo "→ Installing systemd unit..."
+DEST="/etc/systemd/system/cg-dashboard.service"
+sed "s|/home/pi/CommunityGarden/ShowControl/Dashboard|$APP_DIR|g
+     s|User=pi|User=$SERVICE_USER|g" \
+    "$SCRIPT_DIR/dashboard.service" > "$DEST"
+echo "   written: $DEST"
+
+# ── Enable + start ─────────────────────────────────────────────────────────────
+systemctl daemon-reload
+systemctl enable cg-dashboard.service
+systemctl restart cg-dashboard.service
+
+echo ""
+echo "=== Done ==="
+echo "Status:  sudo systemctl status cg-dashboard"
+echo "Logs:    journalctl -u cg-dashboard -f"
+echo "URL:     http://$(hostname -I | awk '{print $1}'):9000/"

--- a/ShowControl/FlowerBeds/deploy/flowerbeds.service
+++ b/ShowControl/FlowerBeds/deploy/flowerbeds.service
@@ -1,13 +1,13 @@
 [Unit]
-Description=FundingCAPTCHA Game Server
+Description=FlowerBeds Show Control
 After=network.target
 Documentation=https://github.com/Impractical-Instruments/CommunityGarden/blob/main/docs/operations.md
-# Remove --camera if the Orbbec camera is not present on this install.
-# Use --mock-camera to emit fake blobs for testing without hardware.
+# Remove --no-osc if OSC controllers are present on the network.
+# Remove --no-visualizer to enable the live WebSocket debug view.
 
 [Service]
-WorkingDirectory=/home/pi/CommunityGarden/ShowControl/FundingCAPTCHA
-ExecStart=/usr/bin/python3 server.py 8080 --camera
+WorkingDirectory=/home/pi/CommunityGarden/ShowControl/FlowerBeds
+ExecStart=/usr/bin/python3 main.py --config settings.json
 Restart=always
 RestartSec=5
 User=pi
@@ -15,7 +15,7 @@ User=pi
 SupplementaryGroups=video plugdev
 StandardOutput=journal
 StandardError=journal
-SyslogIdentifier=captcha
+SyslogIdentifier=flowerbeds
 
 [Install]
 WantedBy=multi-user.target

--- a/ShowControl/FlowerBeds/deploy/install.sh
+++ b/ShowControl/FlowerBeds/deploy/install.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# install.sh — set up FlowerBeds as an auto-starting systemd service.
+# Run once after cloning the repo:
+#   cd ShowControl/FlowerBeds/deploy
+#   sudo bash install.sh
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+APP_DIR="$REPO_ROOT/ShowControl/FlowerBeds"
+SERVICE_USER="${SUDO_USER:-pi}"
+
+echo "=== FlowerBeds install ==="
+echo "App dir: $APP_DIR"
+echo "User:    $SERVICE_USER"
+echo ""
+
+# ── Python dependencies ────────────────────────────────────────────────────────
+echo "→ Installing Python dependencies..."
+# numpy and scipy from apt are faster on Pi/ARM
+apt-get install -y python3-numpy python3-scipy 2>/dev/null || true
+pip3 install --break-system-packages -r "$APP_DIR/requirements.txt"
+
+# ── Install service file ───────────────────────────────────────────────────────
+echo "→ Installing systemd unit..."
+DEST="/etc/systemd/system/flowerbeds.service"
+sed "s|/home/pi/CommunityGarden/ShowControl/FlowerBeds|$APP_DIR|g
+     s|User=pi|User=$SERVICE_USER|g" \
+    "$SCRIPT_DIR/flowerbeds.service" > "$DEST"
+echo "   written: $DEST"
+
+# ── Enable + start ─────────────────────────────────────────────────────────────
+systemctl daemon-reload
+systemctl enable flowerbeds.service
+systemctl restart flowerbeds.service
+
+echo ""
+echo "=== Done ==="
+echo "Status:  sudo systemctl status flowerbeds"
+echo "Logs:    journalctl -u flowerbeds -f"
+echo "Viz:     http://$(hostname -I | awk '{print $1}'):8765/"

--- a/ShowControl/FundingCAPTCHA/deploy/install.sh
+++ b/ShowControl/FundingCAPTCHA/deploy/install.sh
@@ -7,10 +7,13 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
-APP_DIR="$REPO_ROOT/Prototypes/FundingCAPTCHA"
+APP_DIR="$REPO_ROOT/ShowControl/FundingCAPTCHA"
+
+SERVICE_USER="${SUDO_USER:-pi}"
 
 echo "=== FundingCAPTCHA install ==="
 echo "App dir:  $APP_DIR"
+echo "User:     $SERVICE_USER"
 echo ""
 
 # ── Python dependencies ────────────────────────────────────────────────────────
@@ -45,7 +48,8 @@ fi
 echo "→ Installing systemd units..."
 for SVC in captcha.service captcha-kiosk.service; do
     DEST="/etc/systemd/system/$SVC"
-    sed "s|/home/pi/CommunityGarden/Prototypes/FundingCAPTCHA|$APP_DIR|g" \
+    sed "s|/home/pi/CommunityGarden/ShowControl/FundingCAPTCHA|$APP_DIR|g
+         s|User=pi|User=$SERVICE_USER|g" \
         "$SCRIPT_DIR/$SVC" > "$DEST"
     echo "   written: $DEST"
 done

--- a/ShowControl/TreeHouse/deploy/install.sh
+++ b/ShowControl/TreeHouse/deploy/install.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# install.sh — set up TreeHouse as an auto-starting systemd service.
+# Run once after cloning the repo:
+#   cd ShowControl/TreeHouse/deploy
+#   sudo bash install.sh
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+APP_DIR="$REPO_ROOT/ShowControl/TreeHouse"
+SERVICE_USER="${SUDO_USER:-pi}"
+
+echo "=== TreeHouse install ==="
+echo "App dir: $APP_DIR"
+echo "User:    $SERVICE_USER"
+echo ""
+
+# ── Python dependencies ────────────────────────────────────────────────────────
+echo "→ Installing Python dependencies..."
+pip3 install --break-system-packages -r "$APP_DIR/requirements.txt"
+
+# ── Install service file ───────────────────────────────────────────────────────
+echo "→ Installing systemd unit..."
+DEST="/etc/systemd/system/treehouse.service"
+sed "s|/home/pi/CommunityGarden/ShowControl/TreeHouse|$APP_DIR|g
+     s|User=pi|User=$SERVICE_USER|g" \
+    "$SCRIPT_DIR/treehouse.service" > "$DEST"
+echo "   written: $DEST"
+
+# ── Enable + start ─────────────────────────────────────────────────────────────
+systemctl daemon-reload
+systemctl enable treehouse.service
+systemctl restart treehouse.service
+
+echo ""
+echo "=== Done ==="
+echo "Status:  sudo systemctl status treehouse"
+echo "Logs:    journalctl -u treehouse -f"
+echo "Viz:     http://$(hostname -I | awk '{print $1}'):8766/"

--- a/ShowControl/TreeHouse/deploy/treehouse.service
+++ b/ShowControl/TreeHouse/deploy/treehouse.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=TreeHouse Show Control
+After=network.target
+Documentation=https://github.com/Impractical-Instruments/CommunityGarden/blob/main/docs/operations.md
+# Add --no-pico if the Pi Pico is not connected on this install.
+# Add --no-osc to disable the OSC listener.
+
+[Service]
+WorkingDirectory=/home/pi/CommunityGarden/ShowControl/TreeHouse
+ExecStart=/usr/bin/python3 main.py --config settings.json
+Restart=always
+RestartSec=5
+User=pi
+# Pi Pico appears as /dev/ttyACM0 (USB CDC); dialout gives unprivileged access.
+SupplementaryGroups=dialout
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=treehouse
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,162 @@
+# Operations Guide
+
+Process supervision and deployment for CommunityGarden show-control software.
+
+---
+
+## Services overview
+
+Each show-control element runs as a systemd service with `Restart=always` and `RestartSec=5`, so it recovers automatically from crashes without operator intervention.
+
+| Service | Element | Entry point | Default port | Host |
+|---|---|---|---|---|
+| `flowerbeds` | FlowerBeds | `ShowControl/FlowerBeds/main.py` | 8765 (viz) | 192.168.1.11 |
+| `treehouse` | TreeHouse | `ShowControl/TreeHouse/main.py` | 8766 (viz) | 192.168.1.10 |
+| `captcha` | FundingCAPTCHA | `ShowControl/FundingCAPTCHA/server.py` | 8080 | 192.168.1.12 |
+| `captcha-kiosk` | FundingCAPTCHA kiosk | Chromium (kiosk mode) | — | 192.168.1.12 |
+| `cg-dashboard` | Show Dashboard | `ShowControl/Dashboard/serve.py` | 9000 | any |
+
+Playing the Pipes does not yet have a service file; one will be added once the element stub exists.
+
+---
+
+## Quick start (first deploy)
+
+Run on each show computer **as root** after cloning the repo:
+
+```bash
+sudo bash scripts/install-services.sh
+```
+
+To install only specific elements:
+
+```bash
+sudo bash scripts/install-services.sh FlowerBeds TreeHouse
+```
+
+Each element's `deploy/install.sh` can also be run independently:
+
+```bash
+cd ShowControl/FlowerBeds/deploy
+sudo bash install.sh
+```
+
+### What the install script does
+
+1. Installs Python dependencies (`pip3 install -r requirements.txt`)
+2. Copies the service file to `/etc/systemd/system/`, patching the working directory to match the actual repo location
+3. Runs `systemctl enable` + `systemctl restart`
+
+The service user defaults to the invoking user (`$SUDO_USER`) and falls back to `pi`.
+
+---
+
+## Viewing logs
+
+```bash
+# Follow live logs for an element
+journalctl -u flowerbeds -f
+journalctl -u treehouse -f
+journalctl -u captcha -f
+
+# Show logs since last boot
+journalctl -u flowerbeds -b
+
+# Show logs from all CommunityGarden services together
+journalctl -u flowerbeds -u treehouse -u captcha -u cg-dashboard -f
+```
+
+---
+
+## Service management
+
+```bash
+# Status
+sudo systemctl status flowerbeds
+sudo systemctl status treehouse
+sudo systemctl status captcha
+
+# Restart an element (e.g. after a config change)
+sudo systemctl restart flowerbeds
+
+# Stop / start
+sudo systemctl stop flowerbeds
+sudo systemctl start flowerbeds
+
+# Disable auto-start on boot
+sudo systemctl disable flowerbeds
+```
+
+---
+
+## Per-element notes
+
+### FlowerBeds
+
+- **Hardware:** Orbbec depth camera (USB), Arduino OSC controllers (network)
+- **USB groups:** The service user must be in `video` and `plugdev` groups (added by `install.sh` via `SupplementaryGroups`)
+- **Calibration:** On first start the camera captures `calibration_frames` (default 60) to build a background model. This takes several seconds; `Restart=always` handles spurious camera-open failures.
+- **Flags:** Edit `/etc/systemd/system/flowerbeds.service` and add `--no-osc` (no Arduino), `--no-visualizer` (headless), or `--mock-camera` (software testing), then `sudo systemctl daemon-reload && sudo systemctl restart flowerbeds`
+- **Visualizer:** `http://<host>:8765/` — live top-down blob view
+
+### TreeHouse
+
+- **Hardware:** Raspberry Pi (Debian/Ubuntu), Pi Pico over USB serial (`/dev/ttyACM0`)
+- **USB groups:** The service user must be in `dialout` group (added by `install.sh`)
+- **Flags:** Add `--no-pico` to skip serial connection (dev mode)
+- **Visualizer:** `http://<host>:8766/` — live display state view
+
+### FundingCAPTCHA
+
+- **Hardware:** Orbbec depth camera (USB, optional), Chromium kiosk browser
+- **Services:** Two units — `captcha` (Python server) and `captcha-kiosk` (Chromium browser). The kiosk waits for the server to respond before opening.
+- **Flags:** Edit `/etc/systemd/system/captcha.service` to change `--camera` → `--mock-camera` (no hardware) or remove it entirely (pointer-only mode)
+- **Uploads:** Photos saved to `ShowControl/FundingCAPTCHA/uploads/`
+
+### Show Dashboard
+
+- **No hardware dependencies** — pure static file server
+- Opens at `http://<host>:9000/` — links to each element's visualizer
+
+---
+
+## Updating the software
+
+```bash
+cd /home/pi/CommunityGarden   # or wherever the repo lives
+git pull
+
+# Restart affected services
+sudo systemctl restart flowerbeds treehouse captcha cg-dashboard
+```
+
+If Python dependencies changed:
+
+```bash
+pip3 install --break-system-packages -r ShowControl/FlowerBeds/requirements.txt
+pip3 install --break-system-packages -r ShowControl/TreeHouse/requirements.txt
+pip3 install --break-system-packages -r ShowControl/FundingCAPTCHA/requirements.txt
+sudo systemctl restart flowerbeds treehouse captcha
+```
+
+---
+
+## Orbbec camera udev rules
+
+The Orbbec SDK ships udev rules that grant USB access without root. If the camera doesn't open, install the rules (one-time, per machine):
+
+```bash
+# Locate the rules file in the pyorbbecsdk2 package:
+python3 -c "import pyorbbecsdk2; import os; print(os.path.dirname(pyorbbecsdk2.__file__))"
+# Then copy the .rules file to /etc/udev/rules.d/ and reload:
+sudo udevadm control --reload-rules && sudo udevadm trigger
+```
+
+---
+
+## Open questions / future work
+
+- **Playing the Pipes**: once the element stub exists, add `ShowControl/PlayingThePipes/deploy/pipes.service` following the same pattern and add it to `scripts/install-services.sh`.
+- **Multi-machine deploy**: the install script currently runs locally. A simple Ansible playbook or `pdsh` wrapper would let a single operator re-deploy all machines simultaneously.
+- **Health monitoring**: `Restart=always` handles crashes but doesn't alert operators. A lightweight watchdog that posts to a Slack/Discord webhook on repeated restarts would improve unattended operation.
+- **Orbbec SDK version pinning**: `pyorbbecsdk2` must match the SDK `.so` installed on the host. Document the exact version pairing per machine if they diverge.

--- a/scripts/install-services.sh
+++ b/scripts/install-services.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# install-services.sh — install all CommunityGarden show-control services.
+#
+# Run once after cloning the repo on each show computer:
+#   sudo bash scripts/install-services.sh
+#
+# Optional: install a subset of elements:
+#   sudo bash scripts/install-services.sh FlowerBeds TreeHouse
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ "$EUID" -ne 0 ]; then
+    echo "Error: run as root — sudo bash $0"
+    exit 1
+fi
+
+# Default: all elements with a deploy/install.sh
+ALL_ELEMENTS=(FlowerBeds TreeHouse Dashboard FundingCAPTCHA)
+ELEMENTS=("${@:-${ALL_ELEMENTS[@]}}")
+
+echo "=== CommunityGarden service install ==="
+echo "Repo:     $REPO_ROOT"
+echo "Elements: ${ELEMENTS[*]}"
+echo ""
+
+for element in "${ELEMENTS[@]}"; do
+    deploy="$REPO_ROOT/ShowControl/$element/deploy/install.sh"
+    if [ -f "$deploy" ]; then
+        echo "━━━ $element ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        bash "$deploy"
+        echo ""
+    else
+        echo "━━━ $element — no deploy/install.sh found, skipping ━━━━━━━━━"
+        echo ""
+    fi
+done
+
+echo "=== All done ==="
+echo ""
+echo "Service status:"
+for svc in flowerbeds treehouse cg-dashboard captcha; do
+    if systemctl list-unit-files "$svc.service" &>/dev/null; then
+        state=$(systemctl is-active "$svc.service" 2>/dev/null || echo "inactive")
+        printf "  %-20s %s\n" "$svc" "$state"
+    fi
+done
+echo ""
+echo "View logs:  journalctl -u <service> -f"
+echo "Dashboard:  http://$(hostname -I | awk '{print $1}'):9000/"


### PR DESCRIPTION
Implements #issue-29 — PRD §6 unattended-recovery requirement.

## Changes

- **FlowerBeds**: `ShowControl/FlowerBeds/deploy/flowerbeds.service` + `install.sh`
- **TreeHouse**: `ShowControl/TreeHouse/deploy/treehouse.service` + `install.sh`
- **FundingCAPTCHA**: updated existing `captcha.service` + `install.sh` (`Restart=on-failure` → `Restart=always`, `RestartSec=3` → `5`, path fixed from `Prototypes/` → `ShowControl/`)
- **Dashboard** (bonus): `ShowControl/Dashboard/deploy/dashboard.service` + `install.sh`
- `scripts/install-services.sh`: top-level orchestrator installs all elements in one shot
- `docs/operations.md`: service table, log commands, per-element notes, open questions

## Deploy

```bash
sudo bash scripts/install-services.sh
```

## Open questions / future work

- **Playing the Pipes**: service file to be added once element stub exists
- **Multi-machine deploy**: install script runs locally; an Ansible playbook would let a single operator push to all hosts
- **Health alerting**: `Restart=always` recovers silently; a webhook on repeated restarts would improve unattended operation
- **Orbbec udev rules**: documented in `docs/operations.md` but not automated by install script yet

Closes #29

Generated with [Claude Code](https://claude.ai/code)