### PR TITLE
ForgeAndFlora reactive to GardenState (ADR-0008)

### DIFF
--- a/ShowControl/TreeHouse/coordinator.py
+++ b/ShowControl/TreeHouse/coordinator.py
@@ -173,7 +173,8 @@ def load_config(path: str) -> TreehouseConfig:
         led_count=ff.get("led_count", 48),
         blend=ff.get("blend", 0.0),
         transition_speed=ff.get("transition_speed", 0.1),
-        flicker_intensity=ff.get("flicker_intensity", 0.3),
+        base_flicker_intensity=ff.get("base_flicker_intensity", 0.1),
+        max_flicker_intensity=ff.get("max_flicker_intensity", 0.6),
     )
 
     gf = raw["gable_windows"]["front"]
@@ -318,9 +319,6 @@ class Coordinator:
         self._looking_glass: LookingGlassDisplay | None = next(
             (d for d in displays if isinstance(d, LookingGlassDisplay)), None
         )
-        self._forge_and_flora: ForgeAndFloraDisplay | None = next(
-            (d for d in displays if isinstance(d, ForgeAndFloraDisplay)), None
-        )
         self._porch_lights: PorchLightsDisplay | None = next(
             (d for d in displays if isinstance(d, PorchLightsDisplay)), None
         )
@@ -362,10 +360,6 @@ class Coordinator:
     def set_looking_glass_scene(self, scene: str) -> None:
         if self._looking_glass:
             self._looking_glass.set_scene(scene)
-
-    def set_forge_mode(self, mode: str) -> None:
-        if self._forge_and_flora:
-            self._forge_and_flora.set_mode(mode)
 
     def trigger_captcha_blowup(self) -> None:
         log.info("Captcha blowup signalled")

--- a/ShowControl/TreeHouse/displays/effect.py
+++ b/ShowControl/TreeHouse/displays/effect.py
@@ -15,7 +15,8 @@ class ForgeAndFloraConfig:
     led_count: int = 48      # same count on both strips
     blend: float = 0.0       # 0.0 = welding arc, 1.0 = magical gardening
     transition_speed: float = 0.1  # blend units per second
-    flicker_intensity: float = 0.3
+    base_flicker_intensity: float = 0.1   # flicker when garden is quiet
+    max_flicker_intensity: float = 0.6    # flicker at peak captcha+flowerbeds activity
 
 
 class ForgeAndFloraDisplay(LEDControllable):
@@ -41,7 +42,9 @@ class ForgeAndFloraDisplay(LEDControllable):
         self.led_count = config.led_count
         self.blend = config.blend
         self.transition_speed = config.transition_speed
-        self.flicker_intensity = config.flicker_intensity
+        self._base_flicker = config.base_flicker_intensity
+        self._max_flicker = config.max_flicker_intensity
+        self.flicker_intensity = self._base_flicker
         self._target_blend = config.blend
         self._time = 0.0
 
@@ -71,6 +74,14 @@ class ForgeAndFloraDisplay(LEDControllable):
         if not self.enabled:
             return
         self._time += dt
+
+        # pipes_activity drives the arc→bloom crossfade
+        self._target_blend = state.pipes_activity
+
+        # combined captcha + flowerbeds activity drives how dramatic the effects are
+        intensity = min(1.0, (state.captcha_intensity + state.flowerbeds_activity) / 2.0)
+        self.flicker_intensity = self._base_flicker + intensity * (self._max_flicker - self._base_flicker)
+
         delta = self._target_blend - self.blend
         step = self.transition_speed * dt
         if abs(delta) <= step:
@@ -112,6 +123,7 @@ class ForgeAndFloraDisplay(LEDControllable):
             params={
                 "blend": round(self.blend, 3),
                 "target_blend": round(self._target_blend, 3),
+                "flicker_intensity": round(self.flicker_intensity, 3),
                 "transition_speed": self.transition_speed,
                 "arc_pin": self.arc_pin,
                 "bloom_pin": self.bloom_pin,

--- a/ShowControl/TreeHouse/test_forge_and_flora.py
+++ b/ShowControl/TreeHouse/test_forge_and_flora.py
@@ -1,0 +1,114 @@
+"""Tests for ForgeAndFloraDisplay GardenState reactivity — no hardware."""
+import pytest
+
+from displays import GardenState
+from displays.effect import ForgeAndFloraConfig, ForgeAndFloraDisplay
+
+
+def _display(**kwargs) -> ForgeAndFloraDisplay:
+    defaults = dict(arc_pin=2, bloom_pin=3)
+    defaults.update(kwargs)
+    return ForgeAndFloraDisplay(ForgeAndFloraConfig(**defaults))
+
+
+def _state(**kwargs) -> GardenState:
+    return GardenState(**kwargs)
+
+
+def _step(display: ForgeAndFloraDisplay, state: GardenState, dt: float = 0.1) -> None:
+    display.update(dt, state)
+
+
+# ---------------------------------------------------------------------------
+# Blend target — pipes_activity drives the arc→bloom crossfade
+# ---------------------------------------------------------------------------
+
+def test_pipes_zero_targets_arc():
+    d = _display()
+    _step(d, _state(pipes_activity=0.0))
+    assert d._target_blend == 0.0
+
+
+def test_pipes_full_targets_bloom():
+    d = _display()
+    _step(d, _state(pipes_activity=1.0))
+    assert d._target_blend == 1.0
+
+
+def test_pipes_partial_targets_midpoint():
+    d = _display()
+    _step(d, _state(pipes_activity=0.4))
+    assert d._target_blend == pytest.approx(0.4)
+
+
+def test_blend_moves_toward_target_at_transition_speed():
+    # transition_speed=1.0 → blend moves 1.0 units/s; dt=0.1 → moves 0.1
+    d = _display(transition_speed=1.0)
+    _step(d, _state(pipes_activity=1.0), dt=0.1)
+    assert d.blend == pytest.approx(0.1)
+
+
+def test_blend_does_not_overshoot():
+    d = _display(transition_speed=10.0)
+    _step(d, _state(pipes_activity=0.3), dt=1.0)
+    assert d.blend == pytest.approx(0.3)
+
+
+# ---------------------------------------------------------------------------
+# Flicker intensity — driven by combined captcha + flowerbeds activity
+# ---------------------------------------------------------------------------
+
+def test_flicker_at_base_when_garden_quiet():
+    d = _display(base_flicker_intensity=0.1, max_flicker_intensity=0.6)
+    _step(d, _state())  # all signals zero
+    assert d.flicker_intensity == pytest.approx(0.1)
+
+
+def test_flicker_at_max_when_garden_full():
+    d = _display(base_flicker_intensity=0.1, max_flicker_intensity=0.6)
+    _step(d, _state(captcha_intensity=1.0, flowerbeds_activity=1.0))
+    assert d.flicker_intensity == pytest.approx(0.6)
+
+
+def test_flicker_interpolates_at_half_intensity():
+    d = _display(base_flicker_intensity=0.0, max_flicker_intensity=1.0)
+    _step(d, _state(captcha_intensity=0.5, flowerbeds_activity=0.5))
+    # combined = (0.5 + 0.5) / 2 = 0.5
+    assert d.flicker_intensity == pytest.approx(0.5)
+
+
+def test_flicker_clamped_when_signals_exceed_one():
+    # Each signal at 1.0 → combined = (1.0 + 1.0) / 2 = 1.0 → max flicker
+    d = _display(base_flicker_intensity=0.0, max_flicker_intensity=0.8)
+    _step(d, _state(captcha_intensity=1.0, flowerbeds_activity=1.0))
+    assert d.flicker_intensity == pytest.approx(0.8)
+
+
+def test_pipes_activity_does_not_affect_flicker():
+    # pipes drives blend only; flicker should stay at base when only pipes is active
+    d = _display(base_flicker_intensity=0.1, max_flicker_intensity=0.6)
+    _step(d, _state(pipes_activity=1.0))
+    assert d.flicker_intensity == pytest.approx(0.1)
+
+
+# ---------------------------------------------------------------------------
+# Disabled display — update is a no-op
+# ---------------------------------------------------------------------------
+
+def test_disabled_display_does_not_update():
+    d = _display()
+    d.disable()
+    _step(d, _state(pipes_activity=1.0, captcha_intensity=1.0, flowerbeds_activity=1.0))
+    assert d._target_blend == 0.0
+    assert d.blend == 0.0
+    assert d.flicker_intensity == pytest.approx(d._base_flicker)
+
+
+# ---------------------------------------------------------------------------
+# get_state reflects live flicker_intensity
+# ---------------------------------------------------------------------------
+
+def test_get_state_includes_flicker_intensity():
+    d = _display(base_flicker_intensity=0.2, max_flicker_intensity=0.8)
+    _step(d, _state(captcha_intensity=1.0, flowerbeds_activity=1.0))
+    assert d.get_state().params["flicker_intensity"] == pytest.approx(0.8, abs=0.001)


### PR DESCRIPTION
Closes #45.

## Summary

- `ForgeAndFloraDisplay.update()` now reads `GardenState` each frame: `pipes_activity` sets the arc→bloom blend target; combined `captcha_intensity + flowerbeds_activity` scales flicker intensity between `base_flicker_intensity` (quiet garden) and `max_flicker_intensity` (peak activity)
- `ForgeAndFloraConfig` gains `base_flicker_intensity` (default 0.1) and `max_flicker_intensity` (default 0.6), replacing the old static `flicker_intensity` field
- `Coordinator.set_forge_mode()` and `_forge_and_flora` field removed — display is fully self-driving
- `get_state()` now exposes live `flicker_intensity` for the visualizer

## Test plan

- [x] 12 new tests in `test_forge_and_flora.py` — all passing
- [ ] Run TreeHouse with `--no-pico` and confirm Forge & Flora state changes in the visualizer when OSC fabric signals arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)