### PR TITLE
TreeHouse dead-sender policy — zero stale signals after 2×heartbeat (ADR-0007)

### DIFF
--- a/ShowControl/TreeHouse/coordinator.py
+++ b/ShowControl/TreeHouse/coordinator.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -59,6 +60,7 @@ class BranchConfig:
 @dataclass
 class OSCConfig:
     listen_port: int = 9001
+    heartbeat_interval_s: float = 5.0
 
 
 @dataclass
@@ -241,6 +243,7 @@ def load_config(path: str) -> TreehouseConfig:
         ),
         osc=OSCConfig(
             listen_port=network.get("elements", {}).get("treehouse", {}).get("osc_port", 9001),
+            heartbeat_interval_s=float(network.get("heartbeat_interval_s", 5.0)),
         ),
         show=ShowConfig(
             fps=show_raw.get("fps", 30),
@@ -310,7 +313,13 @@ def build_displays(config: TreehouseConfig) -> list[Controllable]:
 class Coordinator:
     """Owns all Controllable instances, drives the frame loop, manages show state."""
 
-    def __init__(self, displays: list[Controllable], branch_config: BranchConfig | None = None) -> None:
+    def __init__(
+        self,
+        displays: list[Controllable],
+        branch_config: BranchConfig | None = None,
+        heartbeat_interval_s: float = 5.0,
+        _clock=None,
+    ) -> None:
         self._displays: dict[str, Controllable] = {d.name: d for d in displays}
         self._led_displays: dict[str, LEDDisplay] = {
             d.name: d for d in displays if isinstance(d, LEDDisplay)
@@ -332,6 +341,10 @@ class Coordinator:
         self._pipes_activity = 0.0
         self._branch_motors: list[BranchMotorConfig] = (branch_config.motors if branch_config else [])
         self._branch_positions: list[tuple[int, float]] = []
+        self._heartbeat_interval = heartbeat_interval_s
+        self._clock = _clock or time.monotonic
+        self._last_received: dict[str, float] = {}
+        self._stale_warned: set[str] = set()
 
     @property
     def brightness(self) -> float:
@@ -370,15 +383,23 @@ class Coordinator:
     def trigger_captcha_blowup(self) -> None:
         log.info("Captcha blowup signalled")
         self._captcha_blowup_pending = True
+        self._touch("captcha")
 
     def set_flowerbeds_activity(self, value: float) -> None:
         self._flowerbeds_activity = max(0.0, min(1.0, value))
+        self._touch("flowerbeds")
 
     def set_captcha_intensity(self, value: float) -> None:
         self._captcha_intensity = max(0.0, min(1.0, value))
+        self._touch("captcha")
 
     def set_pipes_activity(self, value: float) -> None:
         self._pipes_activity = max(0.0, min(1.0, value))
+        self._touch("pipes")
+
+    def _touch(self, sender: str) -> None:
+        self._last_received[sender] = self._clock()
+        self._stale_warned.discard(sender)
 
     def reset_porch_lights(self) -> None:
         if self._porch_lights:
@@ -387,7 +408,28 @@ class Coordinator:
     def get(self, name: str) -> Controllable:
         return self._displays[name]
 
+    def _expire_stale_senders(self) -> None:
+        now = self._clock()
+        timeout = 2.0 * self._heartbeat_interval
+        stale_values = {"flowerbeds": 0.0, "captcha": 0.0, "pipes": 0.0}
+        for sender, last in self._last_received.items():
+            if now - last > timeout:
+                if sender not in self._stale_warned:
+                    log.warning(
+                        "No signal from %s for %.0fs — zeroing contribution",
+                        sender, now - last,
+                    )
+                    self._stale_warned.add(sender)
+                if sender in stale_values:
+                    if sender == "flowerbeds":
+                        self._flowerbeds_activity = 0.0
+                    elif sender == "captcha":
+                        self._captcha_intensity = 0.0
+                    elif sender == "pipes":
+                        self._pipes_activity = 0.0
+
     def update(self, dt: float) -> None:
+        self._expire_stale_senders()
         state = GardenState(
             flowerbeds_activity=self._flowerbeds_activity,
             captcha_intensity=self._captcha_intensity,

--- a/ShowControl/TreeHouse/main.py
+++ b/ShowControl/TreeHouse/main.py
@@ -61,7 +61,11 @@ async def _frame_loop(
 async def _run(args: argparse.Namespace) -> None:
     config = load_config(args.config)
     displays = build_displays(config)
-    coordinator = Coordinator(displays, branch_config=config.branch)
+    coordinator = Coordinator(
+        displays,
+        branch_config=config.branch,
+        heartbeat_interval_s=config.osc.heartbeat_interval_s,
+    )
     coordinator._dim_level = config.show.dim_level
 
     driver = PicoDriver(config.pico.port, config.pico.baud)

--- a/ShowControl/TreeHouse/test_dead_sender.py
+++ b/ShowControl/TreeHouse/test_dead_sender.py
@@ -1,0 +1,163 @@
+"""Tests for Coordinator dead-sender policy (ADR-0007) — no hardware."""
+from coordinator import Coordinator
+
+
+def _coord(heartbeat_interval_s=5.0, start_time=0.0):
+    clock = _FakeClock(start_time)
+    c = Coordinator([], heartbeat_interval_s=heartbeat_interval_s, _clock=clock)
+    return c, clock
+
+
+class _FakeClock:
+    def __init__(self, t=0.0):
+        self.t = t
+
+    def __call__(self):
+        return self.t
+
+    def advance(self, seconds):
+        self.t += seconds
+
+
+# ---------------------------------------------------------------------------
+# Signals are preserved while within the timeout window
+# ---------------------------------------------------------------------------
+
+def test_signal_preserved_before_timeout():
+    c, clock = _coord(heartbeat_interval_s=5.0)
+    c.set_flowerbeds_activity(0.8)
+    clock.advance(9.9)  # just under 2 × 5 s
+    c.update(0.1)
+    assert c._flowerbeds_activity == 0.8
+
+
+def test_all_three_signals_preserved_before_timeout():
+    c, clock = _coord(heartbeat_interval_s=5.0)
+    c.set_flowerbeds_activity(0.5)
+    c.set_captcha_intensity(0.6)
+    c.set_pipes_activity(0.7)
+    clock.advance(9.9)
+    c.update(0.1)
+    assert c._flowerbeds_activity == 0.5
+    assert c._captcha_intensity == 0.6
+    assert c._pipes_activity == 0.7
+
+
+# ---------------------------------------------------------------------------
+# Stale signals are zeroed after 2 × heartbeat_interval_s
+# ---------------------------------------------------------------------------
+
+def test_flowerbeds_zeroed_after_timeout():
+    c, clock = _coord(heartbeat_interval_s=5.0)
+    c.set_flowerbeds_activity(0.9)
+    clock.advance(10.1)
+    c.update(0.1)
+    assert c._flowerbeds_activity == 0.0
+
+
+def test_captcha_intensity_zeroed_after_timeout():
+    c, clock = _coord(heartbeat_interval_s=5.0)
+    c.set_captcha_intensity(0.75)
+    clock.advance(10.1)
+    c.update(0.1)
+    assert c._captcha_intensity == 0.0
+
+
+def test_pipes_zeroed_after_timeout():
+    c, clock = _coord(heartbeat_interval_s=5.0)
+    c.set_pipes_activity(0.4)
+    clock.advance(10.1)
+    c.update(0.1)
+    assert c._pipes_activity == 0.0
+
+
+def test_only_stale_sender_is_zeroed():
+    c, clock = _coord(heartbeat_interval_s=5.0)
+    c.set_flowerbeds_activity(0.9)
+    c.set_pipes_activity(0.5)
+    clock.advance(6.0)
+    # refresh pipes but not flowerbeds
+    c.set_pipes_activity(0.5)
+    clock.advance(4.5)  # flowerbeds now 10.5 s old, pipes only 4.5 s old
+    c.update(0.1)
+    assert c._flowerbeds_activity == 0.0
+    assert c._pipes_activity == 0.5
+
+
+# ---------------------------------------------------------------------------
+# blowup also counts as a captcha heartbeat
+# ---------------------------------------------------------------------------
+
+def test_captcha_blowup_resets_captcha_timeout():
+    c, clock = _coord(heartbeat_interval_s=5.0)
+    c.set_captcha_intensity(0.8)
+    clock.advance(8.0)
+    c.trigger_captcha_blowup()  # refreshes the captcha timestamp
+    clock.advance(4.0)  # 4 s since blowup, well within timeout
+    c.update(0.1)
+    assert c._captcha_intensity == 0.8
+
+
+# ---------------------------------------------------------------------------
+# Recovery: signal resumes after a stale period
+# ---------------------------------------------------------------------------
+
+def test_signal_recovers_after_stale():
+    c, clock = _coord(heartbeat_interval_s=5.0)
+    c.set_flowerbeds_activity(0.9)
+    clock.advance(11.0)
+    c.update(0.1)  # goes stale → 0.0
+    assert c._flowerbeds_activity == 0.0
+
+    c.set_flowerbeds_activity(0.6)  # sender comes back
+    c.update(0.1)
+    assert c._flowerbeds_activity == 0.6
+
+
+# ---------------------------------------------------------------------------
+# Warn once on first stale, clear on recovery
+# ---------------------------------------------------------------------------
+
+def test_stale_warning_issued_once(caplog):
+    import logging
+    c, clock = _coord(heartbeat_interval_s=5.0)
+    c.set_flowerbeds_activity(0.5)
+
+    with caplog.at_level(logging.WARNING, logger="treehouse"):
+        clock.advance(11.0)
+        c.update(0.1)  # first stale → warning
+        clock.advance(5.0)
+        c.update(0.1)  # still stale → no second warning
+
+    warnings = [r for r in caplog.records if "flowerbeds" in r.message and r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+
+
+def test_stale_warning_reissued_after_recovery(caplog):
+    import logging
+    c, clock = _coord(heartbeat_interval_s=5.0)
+    c.set_flowerbeds_activity(0.5)
+
+    with caplog.at_level(logging.WARNING, logger="treehouse"):
+        clock.advance(11.0)
+        c.update(0.1)  # first stale period
+
+        c.set_flowerbeds_activity(0.5)  # recover
+        clock.advance(11.0)
+        c.update(0.1)  # second stale period → new warning
+
+    warnings = [r for r in caplog.records if "flowerbeds" in r.message and r.levelno == logging.WARNING]
+    assert len(warnings) == 2
+
+
+# ---------------------------------------------------------------------------
+# Senders that never sent are not affected (no phantom timeouts)
+# ---------------------------------------------------------------------------
+
+def test_never_sent_sender_not_zeroed():
+    c, clock = _coord(heartbeat_interval_s=5.0)
+    # Don't call set_flowerbeds_activity at all
+    clock.advance(100.0)
+    c.update(0.1)
+    # Still at default 0.0 — no crash, no spurious zeroing
+    assert c._flowerbeds_activity == 0.0


### PR DESCRIPTION
Closes #42.

## Summary

- `Coordinator` tracks a last-received timestamp per sender (`flowerbeds`, `captcha`, `pipes`) via a new `_touch()` helper called by every signal setter and `trigger_captcha_blowup()`
- `_expire_stale_senders()` runs at the top of each `update()` call; any sender silent for more than `2 × heartbeat_interval_s` has its contribution zeroed
- First stale occurrence logs a `WARNING`; warning is suppressed on subsequent frames and re-enabled after the sender recovers
- `heartbeat_interval_s` is read from `network.json` (default 5 s → 10 s timeout) and threaded through `OSCConfig` → `Coordinator`
- A `_clock` injectable replaces direct `time.monotonic()` calls for clean, deterministic testing

## Test plan

- [x] 11 new tests in `test_dead_sender.py` — all passing
- [x] Existing `test_branch_positions.py` — all passing
- [ ] Manual: kill FlowerBeds process while TreeHouse is running; confirm activity zeros within ~10 s and warning appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)