### PR TITLE
Rename ShowMode full→active, off→inactive (ADR-0007)

### DIFF
--- a/ShowControl/TreeHouse/coordinator.py
+++ b/ShowControl/TreeHouse/coordinator.py
@@ -324,7 +324,7 @@ class Coordinator:
         self._porch_lights: PorchLightsDisplay | None = next(
             (d for d in displays if isinstance(d, PorchLightsDisplay)), None
         )
-        self.mode = ShowMode.FULL
+        self.mode = ShowMode.ACTIVE
         self._dim_level = 0.25
         self._captcha_blowup_pending = False
         self._flowerbeds_activity = 0.0
@@ -335,7 +335,7 @@ class Coordinator:
 
     @property
     def brightness(self) -> float:
-        if self.mode == ShowMode.OFF:
+        if self.mode == ShowMode.INACTIVE:
             return 0.0
         if self.mode == ShowMode.DIM:
             return self._dim_level

--- a/ShowControl/TreeHouse/displays/base.py
+++ b/ShowControl/TreeHouse/displays/base.py
@@ -8,9 +8,9 @@ Color = tuple[int, int, int, int]
 
 
 class ShowMode(Enum):
-    FULL = "full"
+    ACTIVE = "active"
     DIM = "dim"
-    OFF = "off"
+    INACTIVE = "inactive"
 
 
 def scale_color(color: Color, factor: float) -> Color:
@@ -36,7 +36,7 @@ class GardenState:
     captcha_intensity: float = 0.0
     captcha_blowup: bool = False
     pipes_activity: float = 0.0
-    show_mode: ShowMode = ShowMode.FULL
+    show_mode: ShowMode = ShowMode.ACTIVE
     brightness: float = 1.0
 
 

--- a/ShowControl/TreeHouse/osc_server.py
+++ b/ShowControl/TreeHouse/osc_server.py
@@ -3,7 +3,7 @@ OSC server — receives show-control messages from other festival elements.
 
 Recognised addresses
 --------------------
-/treehouse/mode        <string>   "full" | "dim" | "off"
+/treehouse/mode        <string>   "active" | "dim" | "inactive"
 /treehouse/brightness  <float>    0.0–1.0  (overrides the dim level in config)
 /flowerbeds/activity   <float>    0.0–1.0  normalised visitor activity from FlowerBeds
 /captcha/intensity     <float>    0.0–1.0  Arc progress toward Blow-Up from FundingCAPTCHA


### PR DESCRIPTION
Closes #37.

## Summary

- `ShowMode.FULL = "full"` → `ShowMode.ACTIVE = "active"`
- `ShowMode.OFF = "off"` → `ShowMode.INACTIVE = "inactive"`
- `GardenState.show_mode` default updated to `ShowMode.ACTIVE`
- `osc_server.py` docstring updated to show new vocabulary

**Breaking:** any TouchOSC layout or external client sending `/treehouse/mode` must switch to `"active"` / `"inactive"`.

## Test plan

- [x] `test_branch_positions.py` — all passing
- [ ] Update any TouchOSC layouts sending `/treehouse/mode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)