### PR TITLE
Dashboard: FastAPI server with mode-relay OSC endpoint (ADR-0007)

### DIFF
--- a/ShowControl/Dashboard/deploy/install.sh
+++ b/ShowControl/Dashboard/deploy/install.sh
@@ -15,6 +15,10 @@ echo "App dir: $APP_DIR"
 echo "User:    $SERVICE_USER"
 echo ""
 
+# ── Install dependencies ───────────────────────────────────────────────────────
+echo "→ Installing Python dependencies..."
+pip3 install --break-system-packages -r "$APP_DIR/requirements.txt"
+
 # ── Install service file ───────────────────────────────────────────────────────
 echo "→ Installing systemd unit..."
 DEST="/etc/systemd/system/cg-dashboard.service"

--- a/ShowControl/Dashboard/requirements.txt
+++ b/ShowControl/Dashboard/requirements.txt
@@ -1,0 +1,7 @@
+# Dashboard server dependencies
+# Install with: pip install -r requirements.txt
+
+fastapi>=0.100
+uvicorn[standard]>=0.23
+python-osc>=1.8
+pydantic>=2.0

--- a/ShowControl/Dashboard/serve.py
+++ b/ShowControl/Dashboard/serve.py
@@ -1,32 +1,117 @@
 #!/usr/bin/env python3
-"""Serve the show dashboard as a static HTTP site.
+"""
+Show dashboard — FastAPI server with mode-relay OSC endpoint.
 
 Usage:
   python serve.py           # default port 9000
   python serve.py 9001      # custom port
 """
 
-import http.server
-import os
+import argparse
+import json
+import logging
 import socket
 import sys
+from pathlib import Path
 
-PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 9000
-os.chdir(os.path.dirname(os.path.abspath(__file__)))
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
 
-try:
-    local_ip = socket.gethostbyname(socket.gethostname())
-except Exception:
-    local_ip = "127.0.0.1"
+DIR = Path(__file__).resolve().parent
+NETWORK_JSON = DIR.parent / "network.json"
 
-print(f"Show Dashboard:  http://{local_ip}:{PORT}/")
-print("Press Ctrl+C to stop.\n")
+VALID_ELEMENTS = {"treehouse", "flowerbeds", "captcha", "pipes"}
+VALID_MODES = {"active", "dim", "inactive"}
 
+log = logging.getLogger("dashboard")
 
-class _QuietHandler(http.server.SimpleHTTPRequestHandler):
-    def log_message(self, *_):
-        pass
+app = FastAPI()
 
 
-with http.server.HTTPServer(("0.0.0.0", PORT), _QuietHandler) as httpd:
-    httpd.serve_forever()
+def _load_network() -> dict:
+    if not NETWORK_JSON.exists():
+        raise FileNotFoundError(f"network.json not found at {NETWORK_JSON}")
+    return json.loads(NETWORK_JSON.read_text())
+
+
+def _send_osc(ip: str, port: int, address: str, value: str) -> None:
+    from pythonosc.udp_client import SimpleUDPClient
+    SimpleUDPClient(ip, port).send_message(address, value)
+
+
+# ---------------------------------------------------------------------------
+# API routes
+# ---------------------------------------------------------------------------
+
+@app.get("/health")
+async def health():
+    return JSONResponse({"ok": True})
+
+
+class ModeRequest(BaseModel):
+    element: str
+    mode: str
+
+
+@app.post("/api/mode")
+async def post_mode(req: ModeRequest):
+    if req.element not in VALID_ELEMENTS:
+        raise HTTPException(400, f"Unknown element {req.element!r}; valid: {sorted(VALID_ELEMENTS)}")
+    if req.mode not in VALID_MODES:
+        raise HTTPException(400, f"Unknown mode {req.mode!r}; valid: {sorted(VALID_MODES)}")
+
+    try:
+        network = _load_network()
+    except FileNotFoundError as exc:
+        raise HTTPException(503, str(exc))
+
+    el = network.get("elements", {}).get(req.element, {})
+    ip = el.get("ip")
+    port = el.get("osc_port")
+    if not ip or not port:
+        raise HTTPException(503, f"No OSC address configured for {req.element!r} in network.json")
+
+    try:
+        _send_osc(ip, int(port), f"/{req.element}/mode", req.mode)
+        log.info("mode relay → /%s/mode %r to %s:%d", req.element, req.mode, ip, port)
+    except Exception as exc:
+        raise HTTPException(502, f"OSC send failed: {exc}")
+
+    return {"ok": True, "element": req.element, "mode": req.mode}
+
+
+# Static files — registered last so API routes take priority
+app.mount("/", StaticFiles(directory=str(DIR), html=True), name="static")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Show dashboard server")
+    parser.add_argument("port", type=int, nargs="?", default=9000)
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    try:
+        local_ip = socket.gethostbyname(socket.gethostname())
+    except Exception:
+        local_ip = "127.0.0.1"
+
+    print(f"Show Dashboard:  http://{local_ip}:{args.port}/")
+    print("Press Ctrl+C to stop.\n")
+
+    uvicorn.run(app, host="0.0.0.0", port=args.port, log_level="warning")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #38.

## Summary

- `serve.py` rewritten: `http.server` → FastAPI + uvicorn
- `POST /api/mode` — validates `element` (treehouse/flowerbeds/captcha/pipes) and `mode` (active/dim/inactive), reads `network.json` for target IP/port, sends `/{element}/mode` via OSC UDP
- `GET /health` — returns `{"ok": true}` for dashboard self-monitoring
- Static files served via `StaticFiles` mount (same behaviour as before for the HTML pages)
- `requirements.txt` added; `deploy/install.sh` updated to pip-install it

## Test plan

- [x] Route registration, input validation, and health endpoint verified via `TestClient`
- [ ] Manual: `curl -X POST http://<host>:9000/api/mode -d '{"element":"treehouse","mode":"dim"}'` and confirm TreeHouse dims

🤖 Generated with [Claude Code](https://claude.com/claude-code)