### PR TITLE
FlowerBeds: ArUco auto-layout calibration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Log/
 **/*.pyo
 .venv/
 *.calibration.npz
+layout_calibrated.json

--- a/IIVision/__init__.py
+++ b/IIVision/__init__.py
@@ -15,7 +15,7 @@ Public API:
 from .pipeline import PreStabilizeFilter, build_calibration, filter_positions_near_points, run_pipeline
 from .blob_stabilizer import BlobStabilizer, StabilizerConfig, TrackedBlob
 from .blob_tracker import BlobTracker, Calibration, Calibrator
-from .camera import MockCamera, OrbbecCamera
+from .camera import MockCamera, OrbbecCamera, OrbbecRGBCamera, RGBFrame
 from .transforms import Rotator, Transform, look_yaw_degrees, orbbec_to_world, rotator_to_matrix, transform_position
 
 __all__ = [
@@ -31,6 +31,8 @@ __all__ = [
     "Calibrator",
     "MockCamera",
     "OrbbecCamera",
+    "OrbbecRGBCamera",
+    "RGBFrame",
     "Rotator",
     "Transform",
     "look_yaw_degrees",

--- a/IIVision/camera.py
+++ b/IIVision/camera.py
@@ -23,7 +23,30 @@ from contextlib import contextmanager
 
 import numpy as np
 
+try:
+    import cv2  # type: ignore[import]
+except ImportError:
+    cv2 = None  # type: ignore[assignment]
+
 from .blob_tracker import CameraIntrinsics, FramePacket
+
+
+# ---------------------------------------------------------------------------
+# RGB frame (used by layout calibrator only)
+# ---------------------------------------------------------------------------
+
+class RGBFrame:
+    """Single BGR color frame from the Orbbec color sensor."""
+
+    def __init__(self, data: np.ndarray, width: int, height: int,
+                 fx: float, fy: float, cx: float, cy: float) -> None:
+        self.data = data          # shape (H, W, 3), BGR
+        self.width = width
+        self.height = height
+        self.fx = fx
+        self.fy = fy
+        self.cx = cx
+        self.cy = cy
 
 
 class BaseCamera(ABC):
@@ -238,3 +261,120 @@ class MockCamera(BaseCamera):
             sleep_s = (1.0 / self.fps) - elapsed
             if sleep_s > 0:
                 time.sleep(sleep_s)
+
+
+# ---------------------------------------------------------------------------
+# Orbbec color-only camera — used exclusively by the layout calibrator
+# ---------------------------------------------------------------------------
+
+class OrbbecRGBCamera:
+    """
+    Opens only the Orbbec COLOR stream and yields RGBFrame objects.
+    Not a BaseCamera subclass — depth pipeline is not involved.
+
+    Typical use:
+        with OrbbecRGBCamera(serial=..., width=1280, height=720, fps=15) as cam:
+            for frame in cam.frames():
+                ...
+    """
+
+    def __init__(
+        self,
+        serial: str | None = None,
+        width: int = 1280,
+        height: int = 720,
+        fps: int = 15,
+    ) -> None:
+        try:
+            from pyorbbecsdk import (  # type: ignore[import]
+                Config, Context, OBFormat, OBSensorType, Pipeline,
+            )
+        except ImportError as exc:
+            raise ImportError(
+                "pyorbbecsdk2 is not installed. Run: pip install pyorbbecsdk2"
+            ) from exc
+
+        self._serial = serial
+        self._width = width
+        self._height = height
+        self._fps = fps
+
+        self._Pipeline = Pipeline
+        self._Config = Config
+        self._Context = Context
+        self._OBSensorType = OBSensorType
+        self._OBFormat = OBFormat
+
+        self._pipeline: object | None = None
+        self._context: object | None = None
+
+    def __enter__(self) -> "OrbbecRGBCamera":
+        if self._serial:
+            self._context = self._Context()
+            device_list = self._context.query_devices()
+            device = device_list.get_device_by_serial_number(self._serial)
+            self._pipeline = self._Pipeline(device)
+        else:
+            self._pipeline = self._Pipeline()
+
+        profile_list = self._pipeline.get_stream_profile_list(
+            self._OBSensorType.COLOR_SENSOR
+        )
+        # Prefer RGB888; fall back to the first available profile.
+        try:
+            profile = profile_list.get_video_stream_profile(
+                self._width, self._height, self._OBFormat.RGB, self._fps
+            )
+        except Exception:
+            profile = profile_list.get_default_video_stream_profile()
+
+        config = self._Config()
+        config.enable_stream(profile)
+        self._pipeline.start(config)
+        return self
+
+    def __exit__(self, *_) -> None:
+        if self._pipeline is not None:
+            self._pipeline.stop()
+            self._pipeline = None
+        self._context = None
+
+    def frames(self) -> Iterator[RGBFrame]:
+        assert self._pipeline is not None, "Camera not opened — use as context manager"
+        while True:
+            frame_set = self._pipeline.wait_for_frames(200)
+            if frame_set is None:
+                continue
+            color_frame = frame_set.get_color_frame()
+            if color_frame is None:
+                continue
+
+            w = color_frame.get_width()
+            h = color_frame.get_height()
+            raw = bytes(color_frame.get_data())
+
+            # Intrinsics from the color stream profile
+            profile = color_frame.get_stream_profile()
+            intr = profile.get_intrinsic()
+
+            # Decode: try raw RGB reshape, fall back to JPEG decode
+            arr: np.ndarray | None = None
+            if len(raw) == w * h * 3:
+                arr = np.frombuffer(raw, dtype=np.uint8).reshape(h, w, 3)
+                arr = cv2.cvtColor(arr, cv2.COLOR_RGB2BGR)
+            else:
+                buf = np.frombuffer(raw, dtype=np.uint8)
+                arr = cv2.imdecode(buf, cv2.IMREAD_COLOR)
+
+            if arr is None:
+                continue
+
+            yield RGBFrame(
+                data=arr,
+                width=w,
+                height=h,
+                fx=intr.fx,
+                fy=intr.fy,
+                cx=intr.cx,
+                cy=intr.cy,
+            )

--- a/ShowControl/Dashboard/flowerbeds.html
+++ b/ShowControl/Dashboard/flowerbeds.html
@@ -10,6 +10,12 @@
 <nav class="nav">
   <a href="index.html">← Dashboard</a>
   <h1>Flower Beds</h1>
+  <button id="cal-btn" onclick="startLayoutCalibrate()"
+          style="margin-left:auto;background:#2a4a7f;color:#eee;border:1px solid #4a7abf;
+                 border-radius:4px;padding:.3em .9em;cursor:pointer;font-family:monospace;font-size:.85em;">
+    Layout Calibrate
+  </button>
+  <span id="cal-msg" style="font-size:.8em;color:#aaa;margin-left:.5em;"></span>
 </nav>
 <div class="detail-body">
   <iframe id="frame" class="content-frame" src=""></iframe>
@@ -54,6 +60,21 @@ function connectLogs() {
 }
 
 connectLogs();
+
+const calBtn = document.getElementById('cal-btn');
+const calMsg = document.getElementById('cal-msg');
+
+function startLayoutCalibrate() {
+  calBtn.disabled = true;
+  calMsg.textContent = 'starting…';
+  fetch(`http://${HOST}:${PORT}/layout-calibrate/start`, { method: 'POST' })
+    .then(r => r.json())
+    .then(d => {
+      calMsg.textContent = d.ok ? 'capturing frames…' : ('error: ' + (d.error || '?'));
+      if (!d.ok) calBtn.disabled = false;
+    })
+    .catch(() => { calMsg.textContent = 'request failed'; calBtn.disabled = false; });
+}
 </script>
 </body>
 </html>

--- a/ShowControl/FlowerBeds/flower_beds.py
+++ b/ShowControl/FlowerBeds/flower_beds.py
@@ -98,6 +98,7 @@ class ModuleConfig:
     registration_point_cm: list[float] = field(default_factory=lambda: [0.0, 0.0, 0.0])
     rotation: dict = field(default_factory=lambda: {"pitch": 0, "yaw": 0, "roll": 0})
     clusters: list[ClusterConfig] = field(default_factory=list)
+    marker_id: int | None = None
 
     @classmethod
     def from_dict(cls, raw: dict) -> "ModuleConfig":

--- a/ShowControl/FlowerBeds/layout_calibrator.py
+++ b/ShowControl/FlowerBeds/layout_calibrator.py
@@ -1,0 +1,237 @@
+"""
+ArUco-based layout calibrator for Flower Beds.
+
+Detects ArUco (DICT_4X4_50) markers in RGB frames and computes world-space
+positions and yaw angles for each module's registration point.
+
+Orientation convention:
+  The tag's +Y axis (upward edge when the ID is readable face-on) maps to the
+  module's forward direction (+Y world, yaw=0).  Point the top of the printed
+  tag toward where you want the module's flowers to face at rest.
+
+CLI usage:
+  python main.py --config settings.json --layout-calibrate
+
+Dashboard usage:
+  POST http://<show-ip>:8765/layout-calibrate/start
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from dataclasses import dataclass
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from IIVision.transforms import Transform, rotator_to_matrix
+
+log = logging.getLogger("flower_beds")
+
+_ARUCO_DICT_ID = cv2.aruco.DICT_4X4_50
+
+# ArUco marker corner order (OpenCV convention, tag local coords, metres):
+#   top-left, top-right, bottom-right, bottom-left  when tag is viewed face-on.
+# X: right, Y: up, Z: out-of-tag (toward camera).
+def _marker_obj_points(half: float) -> np.ndarray:
+    return np.array([
+        [-half,  half, 0.0],
+        [ half,  half, 0.0],
+        [ half, -half, 0.0],
+        [-half, -half, 0.0],
+    ], dtype=np.float32)
+
+
+@dataclass
+class MarkerLayout:
+    marker_id: int
+    registration_point_cm: list[float]
+    yaw_deg: float
+
+
+class LayoutCalibrator:
+    """
+    Accumulates N RGB frames, detects ArUco tags in each, then returns
+    per-module world-space positions and yaw angles averaged over all frames.
+    """
+
+    def __init__(
+        self,
+        fx: float,
+        fy: float,
+        cx: float,
+        cy: float,
+        camera_transform: Transform,
+        tag_size_cm: float,
+        valid_marker_ids: set[int],
+        n_frames: int = 30,
+    ) -> None:
+        self._camera_matrix = np.array(
+            [[fx, 0.0, cx], [0.0, fy, cy], [0.0, 0.0, 1.0]], dtype=np.float64
+        )
+        self._dist = np.zeros(5, dtype=np.float64)
+        self._camera_transform = camera_transform
+        self._half_m = (tag_size_cm / 100.0) / 2.0
+        self._obj_pts = _marker_obj_points(self._half_m)
+        self._valid_ids = valid_marker_ids
+        self._n_frames = n_frames
+
+        aruco_dict = cv2.aruco.getPredefinedDictionary(_ARUCO_DICT_ID)
+        params = cv2.aruco.DetectorParameters()
+        self._detector = cv2.aruco.ArucoDetector(aruco_dict, params)
+
+        # marker_id -> list of (pos_world_cm [3], yaw_deg)
+        self._acc: dict[int, list[tuple[np.ndarray, float]]] = {}
+        self._frame_count = 0
+
+    @property
+    def frames_collected(self) -> int:
+        return self._frame_count
+
+    @property
+    def n_frames(self) -> int:
+        return self._n_frames
+
+    def push(self, bgr_frame: np.ndarray) -> bool:
+        """Process one BGR frame. Returns True once n_frames collected."""
+        corners, ids, _ = self._detector.detectMarkers(bgr_frame)
+
+        if ids is not None:
+            for i, mid in enumerate(ids.flatten()):
+                mid = int(mid)
+                if mid not in self._valid_ids:
+                    continue
+                img_pts = corners[i].reshape(4, 2).astype(np.float32)
+                ok, rvec, tvec = cv2.solvePnP(
+                    self._obj_pts, img_pts, self._camera_matrix, self._dist,
+                    flags=cv2.SOLVEPNP_IPPE_SQUARE,
+                )
+                if not ok:
+                    continue
+                pos_cm, yaw_deg = self._to_world(rvec.flatten(), tvec.flatten())
+                self._acc.setdefault(mid, []).append((pos_cm, yaw_deg))
+
+        self._frame_count += 1
+        return self._frame_count >= self._n_frames
+
+    def _to_world(self, rvec: np.ndarray, tvec: np.ndarray) -> tuple[np.ndarray, float]:
+        """Convert PnP output (camera space, metres) to world pos + yaw."""
+        # tvec: Orbbec camera space (X=right, Y=down, Z=forward), metres.
+        # Axis remap to installation world coords (no scale yet):
+        #   world X = cam X,   world Y = cam Z,   world Z = -cam Y
+        pos_local_cm = np.array([
+            tvec[0] * 100.0,
+            tvec[2] * 100.0,
+            -tvec[1] * 100.0,
+        ])
+        R_cam = rotator_to_matrix(self._camera_transform.rotation)
+        pos_world = R_cam @ pos_local_cm + self._camera_transform.translation
+
+        # Tag +Y axis = module forward direction.
+        R_tag, _ = cv2.Rodrigues(rvec)
+        tag_y_cam = R_tag[:, 1]
+        tag_y_local = np.array([tag_y_cam[0], tag_y_cam[2], -tag_y_cam[1]])
+        tag_y_world = R_cam @ tag_y_local
+
+        # yaw: angle from world +Y (forward) toward +X (right)
+        yaw_deg = float(math.degrees(math.atan2(tag_y_world[0], tag_y_world[1])))
+        return pos_world, yaw_deg
+
+    def build(self) -> dict[int, MarkerLayout]:
+        """Return averaged MarkerLayout per detected marker_id."""
+        results: dict[int, MarkerLayout] = {}
+        for mid, readings in self._acc.items():
+            pos_arr = np.array([r[0] for r in readings])
+            yaw_arr = np.array([r[1] for r in readings])
+            avg_pos = pos_arr.mean(axis=0)
+            avg_yaw = float(math.degrees(math.atan2(
+                np.mean(np.sin(np.radians(yaw_arr))),
+                np.mean(np.cos(np.radians(yaw_arr))),
+            )))
+            results[mid] = MarkerLayout(
+                marker_id=mid,
+                registration_point_cm=[
+                    round(float(avg_pos[0]), 1),
+                    round(float(avg_pos[1]), 1),
+                    round(float(avg_pos[2]), 1),
+                ],
+                yaw_deg=round(avg_yaw, 1),
+            )
+        return results
+
+
+# ---------------------------------------------------------------------------
+# File I/O helpers
+# ---------------------------------------------------------------------------
+
+def save_layout(
+    results: dict[int, MarkerLayout],
+    module_configs: list,
+    output_path: Path,
+) -> list[int]:
+    """
+    Write layout_calibrated.json. Returns list of missing marker IDs.
+    Modules without a marker_id field are skipped silently.
+    """
+    modules_out: dict[str, dict] = {}
+    missing: list[int] = []
+
+    for mod in module_configs:
+        mid = getattr(mod, "marker_id", None)
+        if mid is None:
+            continue
+        if mid not in results:
+            log.warning("marker_id=%d not detected — module keeps existing position", mid)
+            missing.append(mid)
+            continue
+        layout = results[mid]
+        modules_out[str(mid)] = {
+            "registration_point_cm": layout.registration_point_cm,
+            "rotation": {"yaw": layout.yaw_deg},
+        }
+
+    with open(output_path, "w") as f:
+        json.dump({"modules": modules_out}, f, indent=2)
+
+    n_total = sum(1 for m in module_configs if getattr(m, "marker_id", None) is not None)
+    log.info(
+        "Layout saved to %s  (%d/%d modules detected)",
+        output_path, len(modules_out), n_total,
+    )
+    return missing
+
+
+def apply_layout_overrides(settings: dict, layout_path: Path) -> dict:
+    """
+    Merge layout_calibrated.json into settings dict (deep copy).
+    Only registration_point_cm and rotation.yaw are overridden per module.
+    """
+    if not layout_path.exists():
+        return settings
+
+    with open(layout_path) as f:
+        layout = json.load(f)
+
+    overrides = layout.get("modules", {})
+    if not overrides:
+        return settings
+
+    import copy
+    settings = copy.deepcopy(settings)
+    for mod in settings.get("coordinator", {}).get("modules", []):
+        mid = mod.get("marker_id")
+        if mid is None:
+            continue
+        ov = overrides.get(str(mid))
+        if ov is None:
+            continue
+        if "registration_point_cm" in ov:
+            mod["registration_point_cm"] = ov["registration_point_cm"]
+        if "rotation" in ov and "yaw" in ov["rotation"]:
+            mod.setdefault("rotation", {})["yaw"] = ov["rotation"]["yaw"]
+
+    log.info("Applied layout overrides from %s", layout_path)
+    return settings

--- a/ShowControl/FlowerBeds/main.py
+++ b/ShowControl/FlowerBeds/main.py
@@ -19,6 +19,7 @@ import json
 import logging
 import signal
 import sys
+import threading
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -32,9 +33,10 @@ import numpy as np
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from IIVision import (
-    MockCamera, OrbbecCamera, StabilizerConfig, Transform, Rotator,
+    MockCamera, OrbbecCamera, OrbbecRGBCamera, StabilizerConfig, Transform, Rotator,
     Calibration, build_calibration, run_pipeline,
 )
+from layout_calibrator import LayoutCalibrator, apply_layout_overrides, save_layout
 
 from flower_beds import (
     Attraction,
@@ -81,18 +83,113 @@ def _build_controllers(network: dict, no_osc: bool) -> list[SimpleUDPClient]:
 
 
 # ---------------------------------------------------------------------------
+# Layout calibration
+# ---------------------------------------------------------------------------
+
+def _layout_calibrated_path(config_path: str) -> Path:
+    return Path(config_path).with_name("layout_calibrated.json")
+
+
+def run_layout_calibration(
+    settings: dict,
+    config_path: str,
+    camera_transform: Transform,
+    broadcast_fn,
+    mock_camera: bool,
+) -> str:
+    """
+    Capture N RGB frames, detect ArUco tags, write layout_calibrated.json.
+    Returns final calibration_state string for the visualizer.
+    Broadcasts frame-by-frame progress via broadcast_fn.
+    """
+    if mock_camera:
+        log.error("--layout-calibrate requires real camera; mock mode not supported")
+        return "layout_calibrate_error"
+
+    cal_cfg = settings.get("layout_calibration", {})
+    n_frames = int(cal_cfg.get("frames", 30))
+    tag_size_cm = float(cal_cfg.get("tag_size_cm", 40.0))
+
+    coordinator_cfg_raw = settings.get("coordinator", {})
+    from flower_beds import CoordinatorConfig
+    coord_cfg = CoordinatorConfig.from_dict(coordinator_cfg_raw)
+
+    valid_ids = {
+        mod.marker_id
+        for mod in coord_cfg.modules
+        if mod.marker_id is not None
+    }
+    if not valid_ids:
+        log.error("No marker_id fields found in module configs — nothing to calibrate")
+        return "layout_calibrate_error"
+
+    cam_cfg_raw = settings.get("cameras", [{}])[0]
+    from flower_beds import CameraConfig
+    cam_cfg = CameraConfig.from_dict(cam_cfg_raw)
+
+    rgb_cam = OrbbecRGBCamera(
+        serial=cam_cfg.serial or None,
+        width=1280,
+        height=720,
+        fps=15,
+    )
+
+    calibrator: LayoutCalibrator | None = None
+
+    try:
+        with rgb_cam as cam:
+            for frame in cam.frames():
+                if calibrator is None:
+                    calibrator = LayoutCalibrator(
+                        fx=frame.fx, fy=frame.fy, cx=frame.cx, cy=frame.cy,
+                        camera_transform=camera_transform,
+                        tag_size_cm=tag_size_cm,
+                        valid_marker_ids=valid_ids,
+                        n_frames=n_frames,
+                    )
+                done = calibrator.push(frame.data)
+                progress = f"{calibrator.frames_collected}/{n_frames}"
+                broadcast_fn({
+                    "frame": calibrator.frames_collected,
+                    "blobs": [], "clusters": [], "cameras": [],
+                    "calibration_state": f"layout_calibrating:{progress}",
+                })
+                if done:
+                    break
+    except Exception as exc:
+        log.error("Layout calibration failed: %s", exc)
+        return "layout_calibrate_error"
+
+    if calibrator is None:
+        log.error("No frames received from RGB camera")
+        return "layout_calibrate_error"
+
+    results = calibrator.build()
+    output_path = _layout_calibrated_path(config_path)
+    missing = save_layout(results, coord_cfg.modules, output_path)
+    if missing:
+        log.warning("Missing markers: %s", missing)
+
+    return "layout_calibrated"
+
+
+# ---------------------------------------------------------------------------
 # Main loop
 # ---------------------------------------------------------------------------
 
 def run(args: argparse.Namespace) -> None:
-    settings = load_settings(args.config)
+    raw_settings = load_settings(args.config)
     try:
         network = load_network_config()
     except FileNotFoundError as exc:
         log.warning("%s — OSC fabric disabled", exc)
         network = {}
 
-    # --- camera ---
+    # Apply layout overrides if present
+    layout_path = _layout_calibrated_path(args.config)
+    settings = apply_layout_overrides(raw_settings, layout_path)
+
+    # --- camera config (shared across restarts) ---
     raw_cameras = settings.get("cameras", [])
     if not raw_cameras:
         log.error("No cameras defined in settings")
@@ -115,12 +212,6 @@ def run(args: argparse.Namespace) -> None:
         )
         log.info("Using Orbbec camera serial=%s", cam_cfg.serial)
 
-    # --- coordinator ---
-    coordinator = Coordinator.from_config(CoordinatorConfig.from_dict(settings.get("coordinator", {})))
-    log.info("Loaded %d module(s), %d cluster(s) total",
-             len(coordinator.modules),
-             sum(len(m.clusters) for m in coordinator.modules))
-
     # --- OSC controllers (servo hardware) ---
     controllers = _build_controllers(network, args.no_osc)
     if controllers:
@@ -137,9 +228,13 @@ def run(args: argparse.Namespace) -> None:
         log.info("OSC fabric → TreeHouse %s:%d", th["ip"], th["osc_port"])
 
     # --- visualizer ---
+    _layout_calibrate_event = threading.Event()
+
     if not args.no_visualizer:
-        from visualizer import broadcast, start_server
+        from visualizer import broadcast, register_layout_calibrate_callback, start_server
         start_server(host="0.0.0.0", port=args.visualizer_port)
+        if not args.mock_camera:
+            register_layout_calibrate_callback(lambda: _layout_calibrate_event.set())
     else:
         def broadcast(_state):  # noqa: F811
             pass
@@ -155,25 +250,6 @@ def run(args: argparse.Namespace) -> None:
         stab_cfg.min_confirm_frames,
     )
 
-    excl_filter = coordinator.make_exclusion_filter()
-
-    # --- calibration ---
-    calib_path = Path(args.config).with_suffix(".calibration.npz")
-    calibration: Calibration | None = None
-    if not args.recalibrate and calib_path.exists():
-        try:
-            calibration = Calibration.load(calib_path)
-            log.info("Loaded calibration from %s", calib_path)
-        except Exception as exc:
-            log.warning("Calibration load failed (%s) — recalibrating", exc)
-
-    if calibration is None:
-        calibration = build_calibration(camera, calib_frames)
-        calibration.save(calib_path)
-        log.info("Calibration saved to %s", calib_path)
-
-    calibration_state = "calibrated"
-
     # --- graceful shutdown ---
     _running = True
 
@@ -185,51 +261,102 @@ def run(args: argparse.Namespace) -> None:
     signal.signal(signal.SIGINT, _stop)
     signal.signal(signal.SIGTERM, _stop)
 
-    frame_count = 0
-    t_last_log = time.monotonic()
+    # --- depth calibration (persisted, reused across restarts) ---
+    calib_path = Path(args.config).with_suffix(".calibration.npz")
+    calibration: Calibration | None = None
+    if not args.recalibrate and calib_path.exists():
+        try:
+            calibration = Calibration.load(calib_path)
+            log.info("Loaded calibration from %s", calib_path)
+        except Exception as exc:
+            log.warning("Calibration load failed (%s) — recalibrating", exc)
+    if calibration is None:
+        calibration = build_calibration(camera, calib_frames)
+        calibration.save(calib_path)
+        log.info("Calibration saved to %s", calib_path)
 
-    for tracked in run_pipeline(camera, camera_transform, calibration, stab_cfg, excl_filter):
+    calibration_state = "calibrated"
+
+    # --- outer restart loop (re-entered after layout calibration) ---
+    while _running:
+        # Rebuild coordinator from current settings (picks up layout overrides on restart)
+        active_settings = apply_layout_overrides(raw_settings, layout_path)
+        coordinator = Coordinator.from_config(
+            CoordinatorConfig.from_dict(active_settings.get("coordinator", {}))
+        )
+        log.info(
+            "Coordinator: %d module(s), %d cluster(s)",
+            len(coordinator.modules),
+            sum(len(m.clusters) for m in coordinator.modules),
+        )
+        excl_filter = coordinator.make_exclusion_filter()
+
+        frame_count = 0
+        t_last_log = time.monotonic()
+
+        for tracked in run_pipeline(camera, camera_transform, calibration, stab_cfg, excl_filter):
+            if not _running:
+                break
+            if _layout_calibrate_event.is_set():
+                break
+
+            commands = coordinator.process_tracked_blobs(tracked)
+            for ctrl in controllers:
+                for cmd in commands:
+                    ctrl.send_message(_OSC_ADDRESS, cmd.to_osc_args())
+
+            if fabric is not None:
+                activity = min(1.0, len(tracked) / activity_max_blobs)
+                fabric.report("activity", activity)
+                fabric.tick(1.0 / cam_cfg.framerate)
+
+            frame_count += 1
+            state: VisualizerState = {
+                "frame": frame_count,
+                "blobs": [
+                    {
+                        "id": t.stable_id,
+                        "x": float(t.world_pos_cm[0]),
+                        "y": float(t.world_pos_cm[1]),
+                    }
+                    for t in tracked
+                ],
+                "clusters": coordinator.snapshot(),
+                "cameras": [
+                    {
+                        "name": cam_cfg.name,
+                        "x": float(cam_cfg.pos_cm[0]),
+                        "y": float(cam_cfg.pos_cm[1]),
+                        "yaw_deg": float(cam_cfg.rotation.get("yaw", 0)),
+                    }
+                ],
+                "calibration_state": calibration_state,
+            }
+            broadcast(state)
+
+            now = time.monotonic()
+            if now - t_last_log >= 5.0:
+                log.info("frame %d | tracked_blobs=%d", frame_count, len(tracked))
+                t_last_log = now
+
         if not _running:
             break
 
-        commands = coordinator.process_tracked_blobs(tracked)
-        for ctrl in controllers:
-            for cmd in commands:
-                ctrl.send_message(_OSC_ADDRESS, cmd.to_osc_args())
-
-        if fabric is not None:
-            activity = min(1.0, len(tracked) / activity_max_blobs)
-            fabric.report("activity", activity)
-            fabric.tick(1.0 / cam_cfg.framerate)
-
-        frame_count += 1
-        state: VisualizerState = {
-            "frame": frame_count,
-            "blobs": [
-                {
-                    "id": t.stable_id,
-                    "x": float(t.world_pos_cm[0]),
-                    "y": float(t.world_pos_cm[1]),
-                }
-                for t in tracked
-            ],
-            "clusters": coordinator.snapshot(),
-            "cameras": [
-                {
-                    "name": cam_cfg.name,
-                    "x": float(cam_cfg.pos_cm[0]),
-                    "y": float(cam_cfg.pos_cm[1]),
-                    "yaw_deg": float(cam_cfg.rotation.get("yaw", 0)),
-                }
-            ],
-            "calibration_state": calibration_state,
-        }
-        broadcast(state)
-
-        now = time.monotonic()
-        if now - t_last_log >= 5.0:
-            log.info("frame %d | tracked_blobs=%d", frame_count, len(tracked))
-            t_last_log = now
+        # Layout calibration requested (dashboard or will be handled in CLI path)
+        if _layout_calibrate_event.is_set():
+            _layout_calibrate_event.clear()
+            log.info("Starting layout calibration…")
+            calibration_state = run_layout_calibration(
+                raw_settings, args.config, camera_transform, broadcast, args.mock_camera
+            )
+            # Reload depth calibration (camera was re-opened by RGB calibrator)
+            if calib_path.exists():
+                try:
+                    calibration = Calibration.load(calib_path)
+                except Exception:
+                    calibration = build_calibration(camera, calib_frames)
+                    calibration.save(calib_path)
+            log.info("Restarting show pipeline with updated layout…")
 
 
 # ---------------------------------------------------------------------------
@@ -291,6 +418,37 @@ def run_calibrate(args: argparse.Namespace) -> None:
         time.sleep(0.5)
 
 
+def run_layout_calibrate_cli(args: argparse.Namespace) -> None:
+    """CLI entry point for --layout-calibrate."""
+    if args.mock_camera:
+        log.error("--layout-calibrate requires a real camera; --mock-camera not supported")
+        sys.exit(1)
+
+    settings = load_settings(args.config)
+    raw_cameras = settings.get("cameras", [])
+    if not raw_cameras:
+        log.error("No cameras defined in settings")
+        sys.exit(1)
+
+    cam_cfg = CameraConfig.from_dict(raw_cameras[0])
+    camera_transform = Transform(
+        translation=np.array(cam_cfg.pos_cm, dtype=float),
+        rotation=Rotator(**cam_cfg.rotation),
+    )
+
+    def _no_broadcast(_state):
+        pass
+
+    state = run_layout_calibration(
+        settings, args.config, camera_transform, _no_broadcast, mock_camera=False
+    )
+    if state == "layout_calibrated":
+        log.info("Done. Run normally to use the new layout.")
+    else:
+        log.error("Layout calibration failed.")
+        sys.exit(1)
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(description="Flower Beds standalone show control")
     ap.add_argument("--config", default="settings.json", help="Path to settings JSON")
@@ -300,6 +458,8 @@ def main() -> None:
     ap.add_argument("--visualizer-port", type=int, default=8765, help="Visualizer HTTP port")
     ap.add_argument("--recalibrate", action="store_true",
                     help="Ignore saved calibration and recalibrate from scratch")
+    ap.add_argument("--layout-calibrate", action="store_true",
+                    help="Detect ArUco markers and write layout_calibrated.json, then exit")
     ap.add_argument("--verbose", "-v", action="store_true")
     ap.add_argument(
         "--calibrate-yaw", type=float, metavar="DEG", default=None,
@@ -315,6 +475,8 @@ def main() -> None:
 
     if args.calibrate_yaw is not None:
         run_calibrate(args)
+    elif args.layout_calibrate:
+        run_layout_calibrate_cli(args)
     else:
         run(args)
 

--- a/ShowControl/FlowerBeds/requirements.txt
+++ b/ShowControl/FlowerBeds/requirements.txt
@@ -4,6 +4,7 @@ python-osc>=1.8
 fastapi>=0.100
 uvicorn[standard]>=0.23
 websockets>=11
+opencv-python>=4.8
 
 # Orbbec camera SDK
 pyorbbecsdk2

--- a/ShowControl/FlowerBeds/settings.json
+++ b/ShowControl/FlowerBeds/settings.json
@@ -1,5 +1,10 @@
 {
   "calibration_frames": 60,
+  "layout_calibration": {
+    "_comment": "ArUco auto-layout — place 40cm DICT_4X4_50 tags at each module's registration point",
+    "frames": 30,
+    "tag_size_cm": 40.0
+  },
   "stabilizer": {
     "_comment": "Cross-frame blob ID tracking and EMA de-jittering",
     "max_match_dist_cm": 80.0,
@@ -20,6 +25,7 @@
     },
     "modules": [
       {
+        "marker_id": 0,
         "registration_point_cm": [
           -40,
           -84,

--- a/ShowControl/FlowerBeds/visualizer.py
+++ b/ShowControl/FlowerBeds/visualizer.py
@@ -15,7 +15,7 @@ import json
 import logging
 import threading
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any, Callable, TypedDict
 
 import uvicorn  # type: ignore[import]
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect  # type: ignore[import]
@@ -74,6 +74,12 @@ _HTML = """<!DOCTYPE html>
   #legend { font-size:.75em; color:#aaa; margin:.4em; display:flex; gap:1.5em; }
   .dot { display:inline-block; width:10px; height:10px; border-radius:50%;
          margin-right:4px; vertical-align:middle; }
+  #cal-bar { margin:.3em 0; display:flex; align-items:center; gap:.8em; }
+  #cal-btn { background:#2a4a7f; color:#eee; border:1px solid #4a7abf; border-radius:4px;
+             padding:.3em .9em; cursor:pointer; font-family:monospace; font-size:.85em; }
+  #cal-btn:hover { background:#3a5a9f; }
+  #cal-btn:disabled { opacity:.4; cursor:default; }
+  #cal-msg { font-size:.8em; color:#aaa; }
 </style>
 </head>
 <body>
@@ -84,6 +90,10 @@ _HTML = """<!DOCTYPE html>
   <span><span class="dot" style="background:#ff6b6b"></span>cluster (no target)</span>
   <span><span class="dot" style="background:#51cf66"></span>cluster (has target)</span>
   <span><span class="dot" style="background:#ffd43b"></span>camera</span>
+</div>
+<div id="cal-bar">
+  <button id="cal-btn" onclick="startLayoutCalibrate()">Layout Calibrate</button>
+  <span id="cal-msg"></span>
 </div>
 <canvas id="c"></canvas>
 <script>
@@ -263,6 +273,7 @@ function connect() {
   ws.onmessage = (ev) => {
     lastState = JSON.parse(ev.data);
     draw(lastState);
+    updateCalUI(lastState);
     const nb = (lastState.blobs || []).length;
     const nc = (lastState.clusters || []).length;
     status.textContent =
@@ -273,6 +284,47 @@ function connect() {
 }
 
 connect();
+
+// ------------------------------------------------------------------ layout calibrate
+const calBtn = document.getElementById('cal-btn');
+const calMsg = document.getElementById('cal-msg');
+
+function startLayoutCalibrate() {
+  calBtn.disabled = true;
+  calMsg.textContent = 'starting…';
+  fetch('/layout-calibrate/start', { method: 'POST' })
+    .then(r => r.json())
+    .then(d => {
+      if (d.ok) {
+        calMsg.textContent = 'capturing frames…';
+      } else {
+        calMsg.textContent = 'error: ' + (d.error || 'unknown');
+        calBtn.disabled = false;
+      }
+    })
+    .catch(() => {
+      calMsg.textContent = 'request failed';
+      calBtn.disabled = false;
+    });
+}
+
+// Update cal-msg from calibration_state field in WS messages
+function updateCalUI(state) {
+  const cs = state.calibration_state || '';
+  if (cs.startsWith('layout_calibrating:')) {
+    const prog = cs.slice('layout_calibrating:'.length);
+    calMsg.textContent = 'capturing ' + prog;
+    calBtn.disabled = true;
+  } else if (cs === 'layout_calibrated') {
+    calMsg.textContent = 'layout saved';
+    calBtn.disabled = false;
+  } else if (cs === 'layout_calibrate_error') {
+    calMsg.textContent = 'calibration error — check logs';
+    calBtn.disabled = false;
+  } else {
+    calBtn.disabled = false;
+  }
+}
 
 // Redraw on resize in case canvas size changed
 window.addEventListener('resize', () => { resize(); if (lastState) draw(lastState); });
@@ -290,6 +342,13 @@ app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"])
 _connections: set[WebSocket] = set()
 _log_queues: list[asyncio.Queue] = []
 _loop: asyncio.AbstractEventLoop | None = None
+_layout_calibrate_cb: Callable[[], None] | None = None
+
+
+def register_layout_calibrate_callback(cb: Callable[[], None]) -> None:
+    """Register the function to call when /layout-calibrate/start is hit."""
+    global _layout_calibrate_cb
+    _layout_calibrate_cb = cb
 
 
 class WebSocketLogHandler(logging.Handler):
@@ -317,6 +376,17 @@ async def index():
 
 @app.get("/health")
 async def health():
+    return JSONResponse({"ok": True})
+
+
+@app.post("/layout-calibrate/start")
+async def start_layout_calibrate():
+    if _layout_calibrate_cb is None:
+        return JSONResponse(
+            {"ok": False, "error": "calibration not available (mock mode or no callback)"},
+            status_code=503,
+        )
+    _layout_calibrate_cb()
     return JSONResponse({"ok": True})
 
 

--- a/docs/adr/0009-aruco-auto-layout-for-flower-modules.md
+++ b/docs/adr/0009-aruco-auto-layout-for-flower-modules.md
@@ -1,0 +1,38 @@
+# ADR 0009 — ArUco auto-layout for Flower Bed modules
+
+**Status:** Accepted
+
+## Context
+
+The FlowerBeds installation has 12 flower modules, each with 4 servo clusters. Their world-space positions and orientations are configured manually in `settings.json` (`registration_point_cm`, `rotation.yaw`). At festival setup, modules are placed roughly in position and then precisely measured and typed into config — a slow, error-prone process. Last-minute repositioning (a common reality at festival installs) requires re-measuring and re-editing the file.
+
+The Orbbec depth camera already has a usable color sensor. The camera is mounted overhead looking straight down, giving a clean top-down view of the floor.
+
+## Decision
+
+Add an ArUco-marker-based layout calibration system. A printed marker placed flat at each module's registration point is detected by the overhead camera; the detected pose (position + yaw) is written to a separate `layout_calibrated.json` file that overrides only the spatial fields at runtime.
+
+**Marker format:** DICT_4X4_50, 40 cm square. This size subtends ~46 px at 4 m overhead in a 640 px-wide frame — enough for reliable detection with margin.
+
+**Pose estimation:** `cv2.solvePnP` with `SOLVEPNP_IPPE_SQUARE` gives full 6-DOF pose from the four tag corners. Position is converted from Orbbec camera space to world space using the existing `orbbec_to_world` + `transform_position` pipeline. Yaw is extracted from the tag's +Y axis projected onto the world XY plane. The tag's +Y axis (top edge when the ID is readable) is defined as the module's forward direction.
+
+**Averaging:** 30 frames (configurable via `layout_calibration.frames` in `settings.json`) are accumulated and averaged — position by arithmetic mean, yaw by circular mean — to smooth out single-frame detection noise.
+
+**Override file pattern:** `settings.json` stores manual/default values and remains versioned. `layout_calibrated.json` (gitignored) is written by calibration and loaded automatically at startup. It is sparse: only `registration_point_cm` and `rotation.yaw` per detected module. Deleting the file reverts to manual values.
+
+**Trigger points:**
+- `python main.py --layout-calibrate` — dedicated CLI pass, writes file, exits
+- `POST /layout-calibrate/start` on the visualizer server — pauses the show pipeline (~3 s), runs calibration, resumes with updated coordinator
+
+**Mock mode:** Returns an error and exits. Layout calibration requires real camera hardware.
+
+**Partial results:** If a marker is not detected, a warning is logged and that module keeps its existing position. The file is still written with the modules that were found.
+
+## Consequences
+
+- Repositioning 12 modules goes from ~20 minutes of measuring and typing to ~3 minutes of placing tags and pressing a button.
+- `settings.json` remains the authoritative manual backup; `layout_calibrated.json` can be deleted to restore it instantly.
+- The Orbbec color stream is only opened during calibration (a separate `OrbbecRGBCamera` context); the depth stream is unaffected during normal show operation.
+- `opencv-python` is added as a required dependency.
+- The `marker_id` field must be set in each module's `settings.json` entry and must match the printed tag ID. Mismatch means the module is silently skipped (it has no `marker_id` to look up).
+- Tags must be removed before the show starts — they are not detected during normal operation, but a stray tag on the floor could theoretically be confused for a person blob by the depth tracker.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -95,9 +95,56 @@ sudo systemctl disable flowerbeds
 
 - **Hardware:** Orbbec depth camera (USB), Arduino OSC controllers (network)
 - **USB groups:** The service user must be in `video` and `plugdev` groups (added by `install.sh` via `SupplementaryGroups`)
-- **Calibration:** On first start the camera captures `calibration_frames` (default 60) to build a background model. This takes several seconds; `Restart=always` handles spurious camera-open failures.
+- **Depth calibration:** On first start the camera captures `calibration_frames` (default 60) to build a background model. This takes several seconds; `Restart=always` handles spurious camera-open failures.
 - **Flags:** Edit `/etc/systemd/system/flowerbeds.service` and add `--no-osc` (no Arduino), `--no-visualizer` (headless), or `--mock-camera` (software testing), then `sudo systemctl daemon-reload && sudo systemctl restart flowerbeds`
 - **Visualizer:** `http://<host>:8765/` — live top-down blob view
+
+#### Layout calibration (ArUco auto-layout)
+
+The physical position and orientation of each flower module can be auto-detected from ArUco markers placed at each module's registration point, rather than measured and typed into `settings.json` by hand. Use this any time modules are repositioned.
+
+**What you need**
+
+- 12 printed ArUco markers, **DICT_4X4_50**, one per module, **40 cm square** (laminate if possible)
+- Each module's `marker_id` in `settings.json` must match the printed tag ID (IDs 0–11 by default)
+- The Orbbec camera must be mounted and powered (layout calibration uses the color sensor)
+
+**Tag orientation convention**
+
+Point the **top edge of the tag** (the edge opposite the printed ID number) toward the direction you want the module's flowers to face at rest. That direction becomes `yaw = 0°` for that module.
+
+**Step-by-step workflow**
+
+1. Place all tags flat on the floor at each module's registration point, oriented as above.
+2. Run layout calibration (choose one):
+   - **CLI:** `python main.py --config settings.json --layout-calibrate`
+   - **Dashboard:** open `http://<show-ip>:8765/` and click **Layout Calibrate**
+3. Wait ~3 seconds while the camera captures 30 frames (progress shown in the visualizer).
+4. Remove all tags.
+5. Restart (or continue) the show normally — `layout_calibrated.json` is loaded automatically.
+
+The visualizer's **CAL:** badge turns green and shows `layout_calibrated` when done. Any module whose tag wasn't detected keeps its existing position from `settings.json`; a warning is logged.
+
+**Files**
+
+| File | Purpose |
+|---|---|
+| `settings.json` | Manual/default positions — versioned, never overwritten by calibration |
+| `layout_calibrated.json` | Auto-detected overrides — gitignored, auto-loaded at startup |
+
+Delete `layout_calibrated.json` to revert to the manual positions in `settings.json`.
+
+**Recalibrating after a move**
+
+Stop the service, re-place tags, run `--layout-calibrate` again, remove tags, restart. The new `layout_calibrated.json` replaces the old one.
+
+```bash
+sudo systemctl stop flowerbeds
+python main.py --config settings.json --layout-calibrate
+sudo systemctl start flowerbeds
+```
+
+Or trigger from the dashboard without stopping the service — the show pauses ~3 s and resumes automatically with the updated layout.
 
 ### TreeHouse
 


### PR DESCRIPTION
## Summary

- Place 40 cm DICT_4X4_50 ArUco tags at each module's registration point, run `--layout-calibrate` (or click the dashboard button), remove tags — done. Repositioning 12 modules goes from ~20 min of measuring/typing to ~3 min.
- Writes a sparse `layout_calibrated.json` (gitignored) that overrides `registration_point_cm` and `rotation.yaw` per module at startup. `settings.json` stays clean and versioned.
- Dashboard trigger pauses the show pipeline ~3 s and resumes with the updated layout automatically.

## Changes

- `layout_calibrator.py` — new: ArUco detection, `solvePnP` pose estimation, world-space conversion, multi-frame circular-mean averaging
- `IIVision/camera.py` — `OrbbecRGBCamera` for color-only capture (separate from depth pipeline)
- `flower_beds.py` — `ModuleConfig.marker_id: int | None`
- `main.py` — `--layout-calibrate` CLI flag; restart loop for dashboard-triggered calibration; `apply_layout_overrides` loading on startup
- `visualizer.py` — `POST /layout-calibrate/start`; progress broadcast via `calibration_state`; Layout Calibrate button in embedded HTML
- `ShowControl/Dashboard/flowerbeds.html` — Layout Calibrate button in nav
- `settings.json` — `layout_calibration` config block; `marker_id` on existing module
- `requirements.txt` — `opencv-python>=4.8`
- `docs/operations.md` — layout calibration how-to under FlowerBeds
- `docs/adr/0009` — records design decisions

## Test plan

- [ ] `python -m py_compile` passes on all modified/new Python files
- [ ] `python main.py --config settings.json --mock-camera --no-osc` starts without error (mock mode unaffected)
- [ ] `python main.py --config settings.json --layout-calibrate --mock-camera` exits with clear error ("mock mode not supported")
- [ ] With real camera + printed tags: `--layout-calibrate` writes `layout_calibrated.json` with correct module entries
- [ ] Subsequent normal run loads overrides (check log line "Applied layout overrides from…")
- [ ] Dashboard button triggers calibration, progress shown in visualizer, show resumes after ~3 s
- [ ] Deleting `layout_calibrated.json` reverts to `settings.json` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)