### PR TITLE
Port FundingCAPTCHA games from browser to pygame

### DIFF
--- a/ShowControl/FundingCAPTCHA/audio.py
+++ b/ShowControl/FundingCAPTCHA/audio.py
@@ -1,0 +1,45 @@
+"""
+Triangle-wave note synthesiser for pygame.
+
+Pre-generates Sound objects for each frequency at init time.
+play_note(freq) is non-blocking; multiple notes can overlap.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pygame
+
+SAMPLE_RATE = 44100
+NOTE_DUR    = 0.18   # seconds — matches original JS Web Audio timing
+AMPLITUDE   = 0.30   # 0–1
+
+
+def _make_note(freq: float, dur: float = NOTE_DUR) -> pygame.mixer.Sound:
+    n      = int(SAMPLE_RATE * dur)
+    t      = np.linspace(0, dur, n, endpoint=False)
+    # Triangle wave: 2*|2*(t*f - floor(t*f + 0.5))| - 1
+    phase  = t * freq
+    wave   = 2.0 * np.abs(2.0 * (phase - np.floor(phase + 0.5))) - 1.0
+    # Exponential decay envelope
+    env    = np.exp(-5.0 * t / dur)
+    signal = (wave * env * AMPLITUDE * 32767).astype(np.int16)
+    stereo = np.column_stack([signal, signal])
+    return pygame.sndarray.make_sound(stereo)
+
+
+class Synth:
+    """Pre-baked note cache. Call play(freq_or_index) anywhere."""
+
+    def __init__(self, freqs: list[float]) -> None:
+        if not pygame.mixer.get_init():
+            pygame.mixer.init(frequency=SAMPLE_RATE, size=-16, channels=2, buffer=512)
+        self._notes = {f: _make_note(f) for f in freqs}
+
+    def play(self, freq: float) -> None:
+        snd = self._notes.get(freq)
+        if snd:
+            snd.play()
+
+
+# C D E G pentatonic — matches RhythmGame.NOTES
+RHYTHM_SYNTH_FREQS = [261.6, 293.7, 329.6, 392.0]

--- a/ShowControl/FundingCAPTCHA/background.py
+++ b/ShowControl/FundingCAPTCHA/background.py
@@ -1,0 +1,245 @@
+"""
+Fullscreen background renderer.
+
+Preferred: moderngl hybrid — GLSL shader behind pygame surface texture.
+Fallback: solid-color fill if moderngl is unavailable.
+
+Usage:
+    from background import BackgroundRenderer, NEEDS_OPENGL
+    # Pass NEEDS_OPENGL to pygame.display.set_mode flags
+    bg = BackgroundRenderer(W, H)
+    # Each frame:
+    bg.render(dt, game_surf)   # game_surf is a pygame.Surface with SRCALPHA
+"""
+from __future__ import annotations
+
+import numpy as np
+import pygame
+
+try:
+    import moderngl as _mgl
+    NEEDS_OPENGL = True
+except ImportError:
+    _mgl = None  # type: ignore
+    NEEDS_OPENGL = False
+
+# ── Shared vertex shader ───────────────────────────────────────────────────────
+
+_VERT = """
+#version 330
+in vec2 in_vert;
+out vec2 vUv;
+void main() {
+    vUv = in_vert * 0.5 + 0.5;
+    gl_Position = vec4(in_vert, 0.0, 1.0);
+}
+"""
+
+# ── Per-game background fragment shaders (ported from GLSL ES 1.0) ─────────────
+
+_FRAG_LOBBY = """
+#version 330
+in vec2 vUv;
+uniform float uTime;
+uniform float uEvent;
+uniform float uIntensity;
+out vec4 fragColor;
+void main() {
+    float t = uTime * 0.25;
+    vec3 col = vec3(0.03, 0.02, 0.08);
+    col += vec3(0.05, 0.02, 0.13) * (sin(vUv.x * 3.14159 + t) * 0.5 + 0.5);
+    col += vec3(0.03, 0.04, 0.10) * (cos(vUv.y * 2.0 + t * 0.73) * 0.5 + 0.5);
+    col += vec3(0.18, 0.07, 0.35) * uEvent * 0.7;
+    fragColor = vec4(col, 1.0);
+}
+"""
+
+_FRAG_KEEPAWAY = """
+#version 330
+in vec2 vUv;
+uniform float uTime;
+uniform float uEvent;
+uniform float uIntensity;
+out vec4 fragColor;
+void main() {
+    float stripe = mod(floor(vUv.y * 7.0), 2.0);
+    vec3 col = mix(vec3(0.07, 0.21, 0.06), vec3(0.06, 0.18, 0.05), stripe);
+    float mark = smoothstep(0.025, 0.0, abs(fract(vUv.y * 7.0) - 0.5));
+    col = mix(col, vec3(0.9, 0.9, 0.9), mark * 0.12);
+    float dist = length(vUv - 0.5);
+    float ring = smoothstep(0.018, 0.0, abs(dist - mod(uTime * 1.1, 0.75))) * uEvent;
+    col += vec3(1.0, 0.82, 0.15) * ring * 0.9;
+    col *= 0.52 + uIntensity * 0.18;
+    fragColor = vec4(col, 1.0);
+}
+"""
+
+_FRAG_RHYTHM = """
+#version 330
+in vec2 vUv;
+uniform float uTime;
+uniform float uEvent;
+uniform float uIntensity;
+out vec4 fragColor;
+void main() {
+    float colIdx = floor(vUv.x * 4.0);
+    float colFrac = fract(vUv.x * 4.0);
+    float phase = colIdx * 1.5708;
+    float wave = sin(vUv.y * 22.0 - uTime * 5.0 + phase) * 0.5 + 0.5;
+    wave *= 0.14;
+    float sep = smoothstep(0.06, 0.0, min(colFrac, 1.0 - colFrac));
+    vec3 col = vec3(0.02, 0.04, 0.13);
+    col += vec3(0.0, 0.09, 0.28) * wave;
+    col += vec3(0.06, 0.0, 0.12) * sep;
+    col += col * uIntensity * 0.65;
+    col += vec3(0.12, 0.42, 1.0) * uEvent * 0.45;
+    fragColor = vec4(col, 1.0);
+}
+"""
+
+_FRAG_UPSIDEDOWN = """
+#version 330
+in vec2 vUv;
+uniform float uTime;
+uniform float uEvent;
+uniform float uIntensity;
+out vec4 fragColor;
+void main() {
+    vec2 uv = vUv - 0.5;
+    float angle  = atan(uv.y, uv.x);
+    float radius = length(uv);
+    float spiral = sin(angle * 4.0 - uTime * 1.6 - radius * 10.0) * 0.5 + 0.5;
+    vec3 inner = vec3(0.04, 0.0, 0.10);
+    vec3 outer = vec3(0.13, 0.03, 0.30);
+    vec3 col = mix(inner, outer, radius * 1.8) * (0.48 + spiral * 0.52);
+    col = mix(col, vec3(0.28, 0.0, 0.38), uIntensity * 0.55);
+    col += vec3(0.45, 0.0, 0.65) * uEvent * 0.55;
+    fragColor = vec4(col, 1.0);
+}
+"""
+
+# Composite shader: blits pygame surface (as RGBA texture) over the background.
+_FRAG_COMP = """
+#version 330
+in vec2 vUv;
+uniform sampler2D tex;
+out vec4 fragColor;
+void main() {
+    fragColor = texture(tex, vec2(vUv.x, 1.0 - vUv.y));
+}
+"""
+
+_GAME_FRAGS: dict[str, str] = {
+    "lobby":      _FRAG_LOBBY,
+    "keepaway":   _FRAG_KEEPAWAY,
+    "rhythm":     _FRAG_RHYTHM,
+    "upsidedown": _FRAG_UPSIDEDOWN,
+}
+
+_FALLBACK_COLORS: dict[str, tuple[int, int, int]] = {
+    "lobby":      (8,  5,  20),
+    "keepaway":   (18, 54, 15),
+    "rhythm":     (5,  10, 33),
+    "upsidedown": (10, 0,  26),
+}
+
+# Fullscreen quad vertices for TRIANGLE_STRIP
+_QUAD = np.array([-1, -1, 1, -1, -1, 1, 1, 1], dtype="f4")
+
+
+class BackgroundRenderer:
+    """
+    moderngl-backed renderer. Falls back to solid-color if moderngl unavailable.
+    Instantiate after pygame.display.set_mode() has been called.
+    """
+
+    def __init__(self, W: int, H: int) -> None:
+        self._W         = W
+        self._H         = H
+        self._game      = "lobby"
+        self._u_time    = 0.0
+        self._u_event   = 0.0
+        self._intensity = 0.3
+        self._dead      = not NEEDS_OPENGL
+
+        if self._dead:
+            return
+
+        ctx = _mgl.create_context()
+        self._ctx = ctx
+        vbo = ctx.buffer(_QUAD.tobytes())
+
+        self._bg_progs: dict = {}
+        for name, frag in _GAME_FRAGS.items():
+            try:
+                prog = ctx.program(vertex_shader=_VERT, fragment_shader=frag)
+                vao  = ctx.vertex_array(prog, [(vbo, "2f", "in_vert")])
+                self._bg_progs[name] = (prog, vao)
+            except Exception as exc:
+                print(f"background: shader '{name}' compile failed: {exc}", flush=True)
+
+        comp_prog       = ctx.program(vertex_shader=_VERT, fragment_shader=_FRAG_COMP)
+        self._comp_vao  = ctx.vertex_array(comp_prog, [(vbo, "2f", "in_vert")])
+        if "tex" in comp_prog:
+            comp_prog["tex"].value = 0
+
+        self._tex = ctx.texture((W, H), 4)
+        self._tex.filter = _mgl.LINEAR, _mgl.LINEAR
+
+    # ── Public API ─────────────────────────────────────────────────────────────
+
+    def set_game(self, game: str | None) -> None:
+        self._game = game or "lobby"
+
+    def set_intensity(self, v: float) -> None:
+        self._intensity = float(v)
+
+    def on_event(self, kind: str) -> None:
+        if kind == "win":
+            self._u_event = 1.0
+        elif kind == "lose":
+            self._u_event = 0.8
+        elif kind == "tap":
+            self._u_event = min(1.0, self._u_event + 0.6)
+
+    def render(self, dt: float, surf: pygame.Surface) -> None:
+        """Advance time by dt seconds, then composite surf over the background."""
+        self._u_time  += dt
+        self._u_event  = max(0.0, self._u_event - dt * 2.2)
+
+        if self._dead:
+            disp = pygame.display.get_surface()
+            if disp is not None:
+                disp.fill(_FALLBACK_COLORS.get(self._game, (10, 10, 20)))
+                disp.blit(surf, (0, 0))
+            return
+
+        ctx = self._ctx
+        ctx.viewport = (0, 0, self._W, self._H)
+        ctx.clear(0.0, 0.0, 0.0, 1.0)
+        ctx.disable(_mgl.BLEND)
+
+        key = self._game if self._game in self._bg_progs else "lobby"
+        pair = self._bg_progs.get(key) or self._bg_progs.get("lobby")
+        if pair:
+            prog, vao = pair
+            self._set_uniform(prog, "uTime",      self._u_time)
+            self._set_uniform(prog, "uEvent",     self._u_event)
+            self._set_uniform(prog, "uIntensity", self._intensity)
+            vao.render(_mgl.TRIANGLE_STRIP)
+
+        pixel_data = pygame.image.tostring(surf, "RGBA", True)
+        self._tex.write(pixel_data)
+        self._tex.use(0)
+        ctx.enable(_mgl.BLEND)
+        ctx.blend_func = _mgl.SRC_ALPHA, _mgl.ONE_MINUS_SRC_ALPHA
+        self._comp_vao.render(_mgl.TRIANGLE_STRIP)
+        ctx.disable(_mgl.BLEND)
+
+    @staticmethod
+    def _set_uniform(prog, name: str, value: float) -> None:
+        try:
+            if name in prog:
+                prog[name].value = value
+        except Exception:
+            pass

--- a/ShowControl/FundingCAPTCHA/captcha-settings.json
+++ b/ShowControl/FundingCAPTCHA/captcha-settings.json
@@ -1,14 +1,6 @@
 {
   "_comment": "FundingCAPTCHA runtime config.",
 
-  "screen_rect": {
-    "_comment": "Axis-aligned rect used only by the browser game JS layer (TouchInput). X=right, Z=up. Deleted when games move to pygame (which uses ScreenProjector + screen_corners directly).",
-    "x0": -89,
-    "x1":  73,
-    "z0":  39,
-    "z1":  67
-  },
-
   "detection": {
     "_comment": "Tuned for close-range hand-on-screen. depth_delta_mm must be small enough to catch a hand 1-5cm shallower than the Screen background.",
     "depth_delta_mm":  10,

--- a/ShowControl/FundingCAPTCHA/captcha.py
+++ b/ShowControl/FundingCAPTCHA/captcha.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""
+FundingCAPTCHA pygame client.
+
+Usage:
+  python captcha.py                  # no camera, mouse clicks → grid taps
+  python captcha.py --mock-camera    # blobs from server mock-camera WS
+  python captcha.py --camera         # blobs from server real-camera WS
+  python captcha.py --width 1280 --height 720   # windowed (dev)
+
+The server (server.py) must already be running for WS blob streaming,
+photo loading (/api/photos, /api/pairs), and OSC relay (/api/game-event).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import queue
+import random
+import sys
+import threading
+import time
+from enum import Enum, auto
+from pathlib import Path
+
+import pygame
+import requests
+
+DIR              = Path(__file__).parent
+SETTINGS_PATH    = DIR / "captcha-settings.json"
+SETTINGS_LOCAL   = DIR / "captcha-settings.local.json"
+DEFAULT_SERVER   = "http://localhost:8080"
+FPS              = 60
+LOBBY_AUTO_S     = 5.0   # seconds before lobby auto-starts a game
+RESULT_LINGER_S  = 2.5   # seconds to show win/lose overlay before advancing
+
+# ── Settings ───────────────────────────────────────────────────────────────────
+
+def load_settings() -> dict:
+    s = json.loads(SETTINGS_PATH.read_text()) if SETTINGS_PATH.exists() else {}
+    if SETTINGS_LOCAL.exists():
+        s.update(json.loads(SETTINGS_LOCAL.read_text()))
+    return s
+
+# ── State machine ──────────────────────────────────────────────────────────────
+
+class State(Enum):
+    LOBBY   = auto()
+    PLAYING = auto()
+    WIN     = auto()
+    LOSE    = auto()
+
+# ── Shuffle bag ────────────────────────────────────────────────────────────────
+
+class ShuffleBag:
+    def __init__(self, items: list) -> None:
+        self._items = list(items)
+        self._bag: list = []
+
+    def next(self) -> str:
+        if not self._bag:
+            self._bag = self._items[:]
+            random.shuffle(self._bag)
+        return self._bag.pop()
+
+# ── WebSocket blob thread ──────────────────────────────────────────────────────
+
+def _start_ws_thread(
+    ws_url: str,
+    blob_q: "queue.Queue[list]",
+    stop: threading.Event,
+) -> None:
+    from touch_calibration import _ws_thread
+    status    = ["connecting"]
+    cv_status = [{"state": "unknown"}]
+    threading.Thread(
+        target=_ws_thread,
+        args=(ws_url, blob_q, status, cv_status, stop),
+        daemon=True,
+    ).start()
+
+# ── OSC relay ──────────────────────────────────────────────────────────────────
+
+def _post_game_event(server: str, **kwargs) -> None:
+    try:
+        requests.post(f"{server}/api/game-event", json=kwargs, timeout=1)
+    except Exception:
+        pass
+
+# ── Rendering helpers ──────────────────────────────────────────────────────────
+
+def _draw_lobby(surf: pygame.Surface, W: int, H: int,
+                font_xl: pygame.font.Font, font_md: pygame.font.Font) -> None:
+    title = font_xl.render("FundingCAPTCHA", True, (200, 170, 255))
+    hint  = font_md.render("Touch to play", True, (130, 100, 200))
+    surf.blit(title, title.get_rect(centerx=W // 2, centery=H // 2 - 50))
+    surf.blit(hint,  hint.get_rect(centerx=W // 2,  centery=H // 2 + 30))
+
+def _draw_overlay(surf: pygame.Surface, W: int, H: int,
+                  text: str, font: pygame.font.Font,
+                  color: tuple) -> None:
+    overlay = pygame.Surface((W, H), pygame.SRCALPHA)
+    overlay.fill((0, 0, 0, 140))
+    surf.blit(overlay, (0, 0))
+    label = font.render(text, True, color[:3])
+    surf.blit(label, label.get_rect(centerx=W // 2, centery=H // 2))
+
+# ── Main ───────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="FundingCAPTCHA pygame client")
+    ap.add_argument("--camera",       action="store_true",
+                    help="Connect to server real-camera WS")
+    ap.add_argument("--mock-camera",  action="store_true",
+                    help="Connect to server mock-camera WS")
+    ap.add_argument("--server",  default=DEFAULT_SERVER,
+                    help="Server base URL (default: http://localhost:8080)")
+    ap.add_argument("--width",   type=int, default=0,
+                    help="Window width  (0 = fullscreen)")
+    ap.add_argument("--height",  type=int, default=0,
+                    help="Window height (0 = fullscreen)")
+    args = ap.parse_args()
+
+    use_camera = args.camera or args.mock_camera
+    ws_url     = args.server.replace("http://", "ws://").replace("https://", "wss://") + "/ws"
+
+    settings   = load_settings()
+
+    # Deferred import so background.py can check moderngl availability first
+    from background import BackgroundRenderer, NEEDS_OPENGL
+
+    pygame.init()
+    disp_flags = pygame.DOUBLEBUF
+    if NEEDS_OPENGL:
+        disp_flags |= pygame.OPENGL
+    if args.width == 0:
+        disp_flags |= pygame.FULLSCREEN
+        info = pygame.display.Info()
+        W, H = info.current_w, info.current_h
+    else:
+        W, H = args.width, args.height
+
+    pygame.display.set_mode((W, H), disp_flags)
+    pygame.display.set_caption("FundingCAPTCHA")
+    pygame.mouse.set_visible(False)
+
+    bg        = BackgroundRenderer(W, H)
+    game_surf = pygame.Surface((W, H), pygame.SRCALPHA)
+
+    # Fonts
+    font_xl = pygame.font.SysFont("sans", 80, bold=True)
+    font_lg = pygame.font.SysFont("sans", 56, bold=True)
+    font_md = pygame.font.SysFont("sans", 34)
+
+    # Touch input
+    touch = None
+    blob_q: "queue.Queue[list]" = queue.Queue(maxsize=5)
+    ws_stop = threading.Event()
+
+    if use_camera:
+        corners = settings.get("screen_corners")
+        if corners:
+            from touch_input import TouchInput
+            touch = TouchInput(
+                cols=4, rows=4,
+                screen_corners=corners,
+                dwell_frames=settings.get("blob_dwell_frames", 3),
+                max_plane_dist_cm=settings.get("max_plane_dist_cm", 30.0),
+            )
+        else:
+            print("WARNING: screen_corners missing from captcha-settings.json — "
+                  "camera blobs ignored. Run touch_calibration.py first.", flush=True)
+        _start_ws_thread(ws_url, blob_q, ws_stop)
+
+    # Game registry (import here so games/ is on path)
+    sys.path.insert(0, str(DIR))
+    from games import REGISTRY
+    bag   = ShuffleBag(list(REGISTRY.keys()))
+
+    # State
+    state:         State         = State.LOBBY
+    active_game:   object | None = None
+    active_id:     str | None    = None
+    state_timer:   float         = 0.0
+    pending_tap:   tuple | None  = None
+
+    def on_tap(col: int, row: int) -> None:
+        nonlocal pending_tap
+        pending_tap = (col, row)
+
+    if touch:
+        touch.on_tap = on_tap
+
+    def start_game(game_id: str) -> None:
+        nonlocal active_game, active_id, state, state_timer
+        cls  = REGISTRY[game_id]
+        game = cls(settings, server_url=args.server)
+        if touch:
+            touch.resize(cls.COLS, cls.ROWS)
+        active_game  = game
+        active_id    = game_id
+        state        = State.PLAYING
+        state_timer  = 0.0
+        bg.set_game(game_id)
+        bg.set_intensity(0.0)
+        threading.Thread(
+            target=_post_game_event,
+            args=(args.server,),
+            kwargs={"game": game_id, "event": "start"},
+            daemon=True,
+        ).start()
+
+    clock = pygame.time.Clock()
+    running = True
+
+    while running:
+        dt          = clock.tick(FPS) / 1000.0
+        pending_tap = None
+
+        # ── Drain blob queue ──────────────────────────────────────────────────
+        if use_camera and touch:
+            while True:
+                try:
+                    blobs = blob_q.get_nowait()
+                    touch.update(blobs)
+                except queue.Empty:
+                    break
+
+        # ── Pygame events ─────────────────────────────────────────────────────
+        for ev in pygame.event.get():
+            if ev.type == pygame.QUIT:
+                running = False
+            elif ev.type == pygame.KEYDOWN and ev.key in (pygame.K_q, pygame.K_ESCAPE):
+                running = False
+            elif ev.type == pygame.MOUSEBUTTONDOWN and not use_camera:
+                mx, my = pygame.mouse.get_pos()
+                if state == State.PLAYING and active_game is not None:
+                    gr = active_game.grid_rect(W, H)
+                    if gr.collidepoint(mx, my):
+                        col = int((mx - gr.x) / gr.width  * active_game.COLS)
+                        row = int((my - gr.y) / gr.height * active_game.ROWS)
+                        pending_tap = (col, row)
+                    else:
+                        pending_tap = None
+                else:
+                    pending_tap = (0, 0)   # any click in non-PLAYING states advances
+
+        # ── State machine ─────────────────────────────────────────────────────
+        if state == State.LOBBY:
+            state_timer += dt
+            if pending_tap or state_timer >= LOBBY_AUTO_S:
+                start_game(bag.next())
+
+        elif state == State.PLAYING and active_game is not None:
+            if pending_tap:
+                active_game.on_tap(*pending_tap)
+                bg.on_event("tap")
+                threading.Thread(
+                    target=_post_game_event,
+                    args=(args.server,),
+                    kwargs={"game": active_id, "event": "tap",
+                            **active_game.event_data()},
+                    daemon=True,
+                ).start()
+
+            result = active_game.update(dt)
+            bg.set_intensity(active_game.intensity())
+
+            if result in ("win", "lose"):
+                state       = State.WIN if result == "win" else State.LOSE
+                state_timer = 0.0
+                bg.on_event(result)
+                threading.Thread(
+                    target=_post_game_event,
+                    args=(args.server,),
+                    kwargs={"game": active_id, "event": result,
+                            **active_game.event_data()},
+                    daemon=True,
+                ).start()
+
+            # Check internal win flag (all pairs matched inside on_tap)
+            elif hasattr(active_game, "_won") and active_game._won:
+                state       = State.WIN
+                state_timer = 0.0
+                bg.on_event("win")
+                threading.Thread(
+                    target=_post_game_event,
+                    args=(args.server,),
+                    kwargs={"game": active_id, "event": "win",
+                            **active_game.event_data()},
+                    daemon=True,
+                ).start()
+
+        elif state in (State.WIN, State.LOSE):
+            state_timer += dt
+            if state_timer >= RESULT_LINGER_S:
+                if state == State.WIN and active_game is not None:
+                    active_game.next_level()
+                    state       = State.PLAYING
+                    state_timer = 0.0
+                    bg.set_game(active_id)
+                else:
+                    if active_game is not None:
+                        active_game.destroy()
+                    start_game(bag.next())
+
+        # ── Render ────────────────────────────────────────────────────────────
+        game_surf.fill((0, 0, 0, 0))
+
+        if state == State.LOBBY:
+            _draw_lobby(game_surf, W, H, font_xl, font_md)
+
+        elif state == State.PLAYING and active_game is not None:
+            active_game.render(game_surf, W, H)
+            active_game.render_hud(game_surf, W, H)
+
+        elif state in (State.WIN, State.LOSE) and active_game is not None:
+            active_game.render(game_surf, W, H)
+            active_game.render_hud(game_surf, W, H)
+            if state == State.WIN:
+                _draw_overlay(game_surf, W, H, "YOU DID IT!", font_lg, (80, 255, 120, 255))
+            else:
+                _draw_overlay(game_surf, W, H, "TIME'S UP!", font_lg, (255, 80, 80, 255))
+
+        bg.render(dt, game_surf)
+        pygame.display.flip()
+
+    ws_stop.set()
+    pygame.quit()
+
+
+if __name__ == "__main__":
+    main()

--- a/ShowControl/FundingCAPTCHA/deploy/captcha-pygame.service
+++ b/ShowControl/FundingCAPTCHA/deploy/captcha-pygame.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=FundingCAPTCHA pygame kiosk
+After=captcha.service graphical.target
+Wants=captcha.service
+
+[Service]
+Environment=DISPLAY=:0
+# Wait until the server is up before starting the pygame client
+ExecStartPre=/bin/sh -c 'until curl -sf http://localhost:8080/health > /dev/null 2>&1; do sleep 1; done'
+ExecStart=/usr/bin/python3 /home/pi/CommunityGarden/ShowControl/FundingCAPTCHA/captcha.py --camera
+WorkingDirectory=/home/pi/CommunityGarden/ShowControl/FundingCAPTCHA
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=10
+User=pi
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=captcha-pygame
+
+[Install]
+WantedBy=graphical.target

--- a/ShowControl/FundingCAPTCHA/games/__init__.py
+++ b/ShowControl/FundingCAPTCHA/games/__init__.py
@@ -1,0 +1,7 @@
+from .upsidedown import UpsideDownGame
+
+REGISTRY: dict = {
+    "upsidedown": UpsideDownGame,
+    # "rhythm":     RhythmGame,    # TODO
+    # "keepaway":   KeepawayGame,  # TODO
+}

--- a/ShowControl/FundingCAPTCHA/games/upsidedown.py
+++ b/ShowControl/FundingCAPTCHA/games/upsidedown.py
@@ -1,0 +1,334 @@
+"""
+Upside Down — memory matching game. Port of games/upsidedown.js.
+
+Grid: 4×4 (8 pairs). Pieces are shown upside-down; tap matching pairs to
+flip them right-side-up. Fixed all pairs before the timer hits zero.
+
+Win  → on_win() called
+Lose → on_lose() called (timer reaches zero)
+
+Pair source: GET /api/pairs from FastAPI server. Falls back to DEFAULT_PAIRS.
+Photos: fetched from server as raw image bytes, displayed with circular crop.
+"""
+from __future__ import annotations
+
+import io
+import random
+import threading
+from typing import Any
+
+import pygame
+import requests
+
+COLS = 4
+ROWS = 4
+
+_DEFAULT_PAIRS = [
+    ("Bus",    "Car",    "vehicles"),
+    ("House",  "Shack",  "houses"),
+    ("Tree",   "Pine",   "trees"),
+    ("Soccer", "Football","balls"),
+    ("Dog",    "Cat",    "pets"),
+    ("Apple",  "Orange", "fruits"),
+    ("Moon",   "Star",   "sky"),
+    ("Key",    "Lock",   "locks"),
+]
+
+_TUNING = {
+    "initial_time":   45,
+    "time_min":       20,
+    "time_per_level":  8,
+}
+
+# Colours
+_BG          = (18, 8, 35, 210)
+_CELL_NORMAL = (40, 20, 70, 230)
+_CELL_SEL    = (100, 50, 180, 255)
+_CELL_FIXED  = (30, 120, 60, 230)
+_CELL_FLASH  = (200, 200, 80, 255)
+_CELL_WRONG  = (180, 30, 30, 230)
+_TEXT        = (230, 220, 255)
+_BORDER      = (80, 50, 120)
+_BORDER_SEL  = (160, 100, 255)
+_BORDER_FIXED = (60, 200, 100)
+
+
+def _circular_crop(surf: pygame.Surface, size: int) -> pygame.Surface:
+    """Scale surf to size×size and apply a circular alpha mask."""
+    scaled = pygame.transform.smoothscale(surf, (size, size))
+    mask   = pygame.Surface((size, size), pygame.SRCALPHA)
+    pygame.draw.circle(mask, (255, 255, 255, 255), (size // 2, size // 2), size // 2)
+    result = pygame.Surface((size, size), pygame.SRCALPHA)
+    result.blit(scaled, (0, 0))
+    result.blit(mask, (0, 0), special_flags=pygame.BLEND_RGBA_MIN)
+    return result
+
+
+class UpsideDownGame:
+    COLS = COLS
+    ROWS = ROWS
+
+    def __init__(self, settings: dict, server_url: str = "http://localhost:8080") -> None:
+        self._server      = server_url
+        self._time        = float(_TUNING["initial_time"])
+        self._pair_source: list[Any] = list(_DEFAULT_PAIRS)
+        self._photo_cache: dict[str, pygame.Surface] = {}
+        self._font        = pygame.font.SysFont("sans", 28, bold=True)
+        self._font_sm     = pygame.font.SysFont("sans", 20)
+
+        # Flash state: key → remaining seconds
+        self._flash_cells: dict[str, float] = {}
+
+        self._init_board()
+        threading.Thread(target=self._fetch_pairs, daemon=True).start()
+
+    # ── Pair loading ──────────────────────────────────────────────────────────
+
+    def _fetch_pairs(self) -> None:
+        try:
+            r    = requests.get(f"{self._server}/api/pairs", timeout=3)
+            data = r.json()
+            if isinstance(data, list) and len(data) >= 2:
+                # API format: [{label, a:{url,label}, b:{url,label}}]
+                self._pair_source = data
+                self._init_board()
+        except Exception:
+            pass
+
+    def _piece_label(self, piece: Any) -> str:
+        if isinstance(piece, dict):
+            return piece.get("label", "")
+        return str(piece)
+
+    def _piece_url(self, piece: Any) -> str | None:
+        if isinstance(piece, dict):
+            return piece.get("url")
+        return None
+
+    def _load_photo(self, url: str, size: int) -> pygame.Surface | None:
+        cache_key = f"{url}@{size}"
+        if cache_key in self._photo_cache:
+            return self._photo_cache[cache_key]
+        try:
+            full_url = url if url.startswith("http") else f"{self._server}{url}"
+            r    = requests.get(full_url, timeout=3)
+            surf = pygame.image.load(io.BytesIO(r.content)).convert_alpha()
+            circ = _circular_crop(surf, size)
+            self._photo_cache[cache_key] = circ
+            return circ
+        except Exception:
+            return None
+
+    # ── Board initialisation ──────────────────────────────────────────────────
+
+    def _init_board(self) -> None:
+        self._elapsed  = 0.0
+        self._selected: tuple[int, int] | None = None
+        self._fixed: set[str] = set()
+        self._flash_cells = {}
+        self._alive    = True
+        self._won      = False
+
+        total_cells = COLS * ROWS
+        num_pairs   = total_cells // 2
+
+        pairs = random.sample(self._pair_source, min(num_pairs, len(self._pair_source)))
+        if len(pairs) < num_pairs:
+            pairs = (pairs * (num_pairs // len(pairs) + 1))[:num_pairs]
+
+        cells = [(c, r) for r in range(ROWS) for c in range(COLS)]
+        random.shuffle(cells)
+
+        # pieces[(col, row)] = {pairId, half(0|1), piece}
+        self._pieces: dict[tuple[int, int], dict] = {}
+        for idx, pair in enumerate(pairs):
+            if isinstance(pair, dict):
+                a_piece = pair.get("a", {})
+                b_piece = pair.get("b", {})
+            else:
+                a_piece, b_piece = pair[0], pair[1]
+            ca, ra = cells[idx * 2]
+            cb, rb = cells[idx * 2 + 1]
+            self._pieces[(ca, ra)] = {"pair_id": idx, "half": 0, "piece": a_piece}
+            self._pieces[(cb, rb)] = {"pair_id": idx, "half": 1, "piece": b_piece}
+
+    # ── Game loop ─────────────────────────────────────────────────────────────
+
+    def update(self, dt: float) -> str | None:
+        if not self._alive:
+            return None
+        self._elapsed += dt
+        for k in list(self._flash_cells):
+            self._flash_cells[k] -= dt
+            if self._flash_cells[k] <= 0:
+                del self._flash_cells[k]
+        if self._elapsed >= self._time:
+            self._alive = False
+            return "lose"
+        return None
+
+    def on_tap(self, col: int, row: int) -> None:
+        if not self._alive:
+            return
+        key  = (col, row)
+        slot = self._pieces.get(key)
+        if slot is None or key in self._fixed:
+            return
+
+        if self._selected is None:
+            self._selected = key
+            return
+
+        if self._selected == key:
+            self._selected = None
+            return
+
+        prev_key  = self._selected
+        prev_slot = self._pieces.get(prev_key)
+        self._selected = None
+
+        if prev_slot and prev_slot["pair_id"] == slot["pair_id"] and prev_slot["half"] != slot["half"]:
+            # Match
+            self._fixed.add(key)
+            self._fixed.add(prev_key)
+            self._flash_cells[key]      = 0.5
+            self._flash_cells[prev_key] = 0.5
+            if len(self._fixed) == len(self._pieces):
+                self._alive = False
+                # Win is returned on next update() — set a flag
+                self._won = True
+        else:
+            # Wrong
+            self._flash_cells[key]      = -0.4   # negative = wrong flash
+            self._flash_cells[prev_key] = -0.4
+
+    # ── Rendering ─────────────────────────────────────────────────────────────
+
+    def grid_rect(self, W: int, H: int) -> pygame.Rect:
+        hud_h   = int(H * 0.14)
+        avail_h = H - hud_h
+        cell    = min(W // COLS, avail_h // ROWS)
+        gw, gh  = cell * COLS, cell * ROWS
+        return pygame.Rect((W - gw) // 2, hud_h + (avail_h - gh) // 2, gw, gh)
+
+    def render(self, surf: pygame.Surface, W: int, H: int) -> None:
+        gr       = self.grid_rect(W, H)
+        cell_w   = gr.width  // COLS
+        cell_h   = gr.height // ROWS
+        pad      = max(4, cell_w // 14)
+        img_size = min(cell_w, cell_h) - pad * 2
+
+        # Grid background
+        pygame.draw.rect(surf, _BG, gr, border_radius=12)
+
+        for (c, r), slot in self._pieces.items():
+            key   = (c, r)
+            cx    = gr.x + c * cell_w
+            cy    = gr.y + r * cell_h
+            rect  = pygame.Rect(cx + pad, cy + pad, cell_w - pad * 2, cell_h - pad * 2)
+
+            is_fixed = key in self._fixed
+            is_sel   = key == self._selected
+            flash    = self._flash_cells.get(key, 0)
+            is_match_flash = flash > 0
+            is_wrong_flash = flash < 0
+
+            if is_match_flash:
+                cell_col  = _CELL_FLASH
+                bord_col  = _BORDER_FIXED
+            elif is_wrong_flash:
+                cell_col  = _CELL_WRONG
+                bord_col  = (200, 50, 50)
+            elif is_fixed:
+                cell_col  = _CELL_FIXED
+                bord_col  = _BORDER_FIXED
+            elif is_sel:
+                cell_col  = _CELL_SEL
+                bord_col  = _BORDER_SEL
+            else:
+                cell_col  = _CELL_NORMAL
+                bord_col  = _BORDER
+
+            pygame.draw.rect(surf, cell_col, rect, border_radius=8)
+            pygame.draw.rect(surf, bord_col, rect, width=2, border_radius=8)
+
+            self._draw_piece(surf, slot["piece"], rect, img_size, is_fixed, is_wrong_flash)
+
+    def _draw_piece(
+        self,
+        surf: pygame.Surface,
+        piece: Any,
+        rect: pygame.Rect,
+        img_size: int,
+        is_fixed: bool,
+        is_wrong: bool,
+    ) -> None:
+        url = self._piece_url(piece)
+        label = self._piece_label(piece)
+        cx, cy = rect.centerx, rect.centery
+
+        if url:
+            img = self._load_photo(url, img_size)
+            if img:
+                if not is_fixed:
+                    img = pygame.transform.rotate(img, 180)
+                surf.blit(img, (cx - img_size // 2, cy - img_size // 2))
+                return
+
+        # Text fallback
+        text = self._font.render(label[:8], True, _TEXT)
+        if not is_fixed:
+            text = pygame.transform.rotate(text, 180)
+        surf.blit(text, text.get_rect(center=(cx, cy)))
+
+    def render_hud(self, surf: pygame.Surface, W: int, H: int) -> None:
+        hud_h   = int(H * 0.14)
+        matched = len(self._fixed) // 2
+        total   = len(self._pieces) // 2
+        remaining = max(0.0, self._time - self._elapsed)
+        frac    = remaining / self._time
+        low_time = remaining <= 10
+
+        # Timer bar
+        bar_w = int(W * 0.5)
+        bar_h = 12
+        bar_x = (W - bar_w) // 2
+        bar_y = hud_h - bar_h - 8
+        pygame.draw.rect(surf, (50, 30, 80), (bar_x, bar_y, bar_w, bar_h), border_radius=6)
+        fill_w = int(bar_w * frac)
+        bar_col = (220, 60, 60) if low_time else (80, 180, 80)
+        if fill_w > 0:
+            pygame.draw.rect(surf, bar_col, (bar_x, bar_y, fill_w, bar_h), border_radius=6)
+
+        # Labels
+        time_txt = self._font.render(f"{int(remaining)}s", True,
+                                      (255, 100, 100) if low_time else (200, 240, 200))
+        pair_txt = self._font.render(f"{matched}/{total} pairs", True, (200, 180, 255))
+        title    = self._font_sm.render("Upside Down", True, (140, 100, 200))
+
+        surf.blit(title,    title.get_rect(centerx=W // 2, top=6))
+        surf.blit(time_txt, time_txt.get_rect(right=bar_x - 16, centery=bar_y + bar_h // 2))
+        surf.blit(pair_txt, pair_txt.get_rect(left=bar_x + bar_w + 16, centery=bar_y + bar_h // 2))
+
+    # ── Orchestrator interface ────────────────────────────────────────────────
+
+    def intensity(self) -> float:
+        """Arc intensity: 0 at start, 1 when timer is gone (urgency)."""
+        return 1.0 - max(0.0, min(1.0, (self._time - self._elapsed) / self._time))
+
+    def event_data(self) -> dict:
+        matched = len(self._fixed) // 2
+        total   = max(1, len(self._pieces) // 2)
+        return {
+            "score":         matched,
+            "winScore":      total,
+            "timerFraction": max(0.0, (self._time - self._elapsed) / self._time),
+        }
+
+    def next_level(self) -> None:
+        self._time = max(float(_TUNING["time_min"]),
+                         self._time - _TUNING["time_per_level"])
+        self._init_board()
+
+    def destroy(self) -> None:
+        self._alive = False

--- a/ShowControl/FundingCAPTCHA/requirements.txt
+++ b/ShowControl/FundingCAPTCHA/requirements.txt
@@ -17,5 +17,7 @@ scipy>=1.10
 # Orbbec camera SDK
 pyorbbecsdk2
 
-# ── Touch calibration (touch_calibration.py) ─────────────────────────────────
+# ── pygame client (captcha.py) + touch calibration ───────────────────────────
 pygame>=2.1
+moderngl>=5.8
+requests>=2.28

--- a/ShowControl/FundingCAPTCHA/server.py
+++ b/ShowControl/FundingCAPTCHA/server.py
@@ -3,19 +3,18 @@
 FundingCAPTCHA server — FastAPI + uvicorn.
 
 Usage:
-  python server.py [port]                # browser pointer-only (default 8080)
+  python server.py [port]                # default 8080
   python server.py --mock-camera         # mock blobs via WebSocket (no hardware)
   python server.py --camera              # real Orbbec depth camera
 
 Endpoints:
-  GET  /                       → index.html (kiosk game)
   GET  /upload.html            → kid photo upload page
   GET  /gallery.html           → organiser pairing tool
   POST /upload                 → save base64 photo to uploads/
   GET  /api/photos             → list uploaded photos
   GET  /api/pairs              → Upside Down pairs config
   POST /api/pairs              → save pairs config
-  GET  /api/captcha-settings   → floor rect + camera config (for browser blob mapping)
+  POST /api/game-event         → relay game state to OSC fabric
   WS   /ws                     → pushes {blobs:[{id,x,y}]} when CV thread is running
 """
 
@@ -236,11 +235,6 @@ async def post_pairs(request: Request):
         return {"ok": True, "count": len(pairs)}
     except Exception as e:
         return {"ok": False, "error": str(e)}
-
-
-@app.get("/api/captcha-settings")
-async def get_captcha_settings():
-    return _load_settings()
 
 
 @app.post("/api/game-event")
@@ -495,7 +489,9 @@ async def logs_endpoint(websocket: WebSocket):
             _log_queues.remove(q)
 
 
-# ── Static files (catch-all — must be registered last) ────────────────────────
+# ── Static files ──────────────────────────────────────────────────────────────
+# Serves organiser tools (upload.html, gallery.html) and uploaded photos.
+# The kiosk is now captcha.py (pygame), not a browser page.
 app.mount("/", StaticFiles(directory=str(DIR), html=True), name="static")
 
 

--- a/ShowControl/FundingCAPTCHA/touch_input.py
+++ b/ShowControl/FundingCAPTCHA/touch_input.py
@@ -1,0 +1,59 @@
+"""
+Blob-to-grid touch input for pygame games.
+
+Wraps ScreenProjector + DwellTracker from touch_calibration.py.
+Call update(blobs) each frame; on_tap(col, row) fires once per dwell.
+"""
+from __future__ import annotations
+
+from touch_calibration import DwellTracker, ScreenProjector
+
+
+class TouchInput:
+    def __init__(
+        self,
+        cols: int,
+        rows: int,
+        screen_corners: dict,
+        dwell_frames: int = 3,
+        max_plane_dist_cm: float = 30.0,
+        on_tap=None,
+    ) -> None:
+        self._cols           = cols
+        self._rows           = rows
+        self._dwell_frames   = dwell_frames
+        self._max_dist       = max_plane_dist_cm
+        self.on_tap          = on_tap  # callable(col, row) — set by orchestrator
+        self._projector      = ScreenProjector(
+            screen_corners["bottom_left"],
+            screen_corners["bottom_right"],
+            screen_corners["top_left"],
+        )
+        self._dwell          = DwellTracker(dwell_frames)
+        self._prev_flashing: set[tuple[int, int]] = set()
+
+    def resize(self, cols: int, rows: int) -> None:
+        self._cols  = cols
+        self._rows  = rows
+        self._dwell = DwellTracker(self._dwell_frames)
+        self._prev_flashing = set()
+
+    def update(self, blobs: list[dict]) -> None:
+        live: list[tuple[int, int, int]] = []
+        for b in blobs:
+            xyz = [b["x"], b["y"], b["z"]]
+            if not self._projector.in_bounds_3d(xyz, self._max_dist):
+                continue
+            u, v = self._projector.project(xyz)
+            if not ScreenProjector.in_bounds(u, v):
+                continue
+            col, row = ScreenProjector.uv_to_cell(u, v, self._cols, self._rows)
+            live.append((int(b["id"]), col, row))
+
+        prev = self._prev_flashing
+        self._dwell.update(live)
+        self._prev_flashing = self._dwell.flashing.copy()
+
+        if self.on_tap:
+            for cell in self._prev_flashing - prev:
+                self.on_tap(cell[0], cell[1])

--- a/docs/adr/0011-fundingcaptcha-screen-calibration-and-projection.md
+++ b/docs/adr/0011-fundingcaptcha-screen-calibration-and-projection.md
@@ -18,11 +18,11 @@ The calibration tool enters corner-capture mode when `screen_corners` in `captch
 
 (u, v) maps to (col, row) with v=1 at the top of the Screen (row 0). Games define their own grid dimensions; `ScreenProjector.uv_to_cell()` does the conversion.
 
-**Pygame games** will consume `ScreenProjector` directly — calibrate once, project each frame, map to grid cells. No additional coordinate config needed at the game layer.
+**Pygame games** consume `ScreenProjector` directly via `touch_input.py` — calibrate once, project each frame, map to grid cells. No additional coordinate config needed at the game layer.
 
 ## The `screen_rect` field
 
-`captcha-settings.json` also contains a `screen_rect` (axis-aligned x0/x1/z0/z1 box). This is consumed only by the browser-game JS layer (`TouchInput`), which uses a simpler 2D axis-aligned mapping. It will be deleted when the browser games are replaced by pygame games. It is not derived from `screen_corners` and does not need to stay in sync once the migration is complete.
+`captcha-settings.json` contains a legacy `screen_rect` (axis-aligned x0/x1/z0/z1 box). It was consumed only by the now-removed browser JS `TouchInput` layer. It is safe to delete from `captcha-settings.json`; the pygame client ignores it.
 
 ## Consequences
 

--- a/docs/adr/0012-fundingcaptcha-games-use-pygame-not-browser.md
+++ b/docs/adr/0012-fundingcaptcha-games-use-pygame-not-browser.md
@@ -1,0 +1,34 @@
+# FundingCAPTCHA games use pygame instead of a browser kiosk
+
+The game display layer was originally a browser application (Chromium in kiosk mode via cage/Wayland compositor) served by a FastAPI server. The browser stack was fragile on Raspberry Pi — cage, Chromium, and the readiness-check startup sequence added failure modes with no recovery path.
+
+## Decision
+
+Replace the browser game layer with a pygame application (`captcha.py`). The FastAPI server (`server.py`) is retained for blob WebSocket streaming, OSC relay, and organiser tools (upload.html, gallery.html). The pygame client connects to the server's existing `/ws` WebSocket for blob input and POSTs to `/api/game-event` for OSC relay, exactly as the browser did.
+
+## Architecture
+
+**Background rendering:** `background.py` uses moderngl (OpenGL 3.3) to render per-game GLSL fragment shaders behind the game UI. The pygame game surface is composited over the shader as a texture each frame (hybrid approach: shader background + pygame surface overlay). Falls back to solid-color fill if moderngl is unavailable.
+
+**Touch input:** `touch_input.py` wraps `ScreenProjector` and `DwellTracker` from `touch_calibration.py`. Consumes blob JSON from the server WebSocket; fires `on_tap(col, row)` callbacks on dwell completion. Screen corner calibration (`touch_calibration.py`) is unchanged.
+
+**Dev modes:**
+- `python captcha.py` — mouse clicks map to grid taps (no server required)
+- `python captcha.py --mock-camera` — blobs from server mock-camera WebSocket
+- `python captcha.py --camera` — blobs from server real-camera WebSocket
+
+**Deployment:** `captcha-pygame.service` replaces `captcha-kiosk.service`. Launches pygame under X11 (`DISPLAY=:0`); waits for server `/health` before starting.
+
+## Game port order
+
+1. UpsideDown (`games/upsidedown.py`) — memory match, no audio, proves full stack
+2. Rhythm (`games/rhythm.py`) — adds numpy/pygame triangle-wave audio synth
+3. Keepaway (`games/keepaway.py`) — adds AI defenders and real-time movement
+
+## Consequences
+
+- `captcha-kiosk.service`, `cage`, and Chromium are no longer needed on the kiosk Pi.
+- Browser game files (`index.html`, `main.js`, `grid.js`, `touch-input.js`, `blob-ws.js`, `background-renderer.js`, `style.css`, `games/*.js`) are deleted after each pygame game is verified working.
+- `screen_rect` in `captcha-settings.json` is now unused and can be deleted.
+- `GET /api/captcha-settings` endpoint is removed from `server.py` (pygame reads the file directly).
+- Organiser browser tools (upload.html, gallery.html) remain browser-based, served by FastAPI.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -22,7 +22,7 @@ Each show-control element runs as a systemd service with `Restart=always` and `R
 | `flowerbeds` | FlowerBeds | `ShowControl/FlowerBeds/main.py` | 8765 (viz) | 192.168.1.11 |
 | `treehouse` | TreeHouse | `ShowControl/TreeHouse/main.py` | 8766 (viz) | 192.168.1.10 |
 | `captcha` | FundingCAPTCHA | `ShowControl/FundingCAPTCHA/server.py` | 8080 | 192.168.1.12 |
-| `captcha-kiosk` | FundingCAPTCHA kiosk | Chromium (kiosk mode) | — | 192.168.1.12 |
+| `captcha-pygame` | FundingCAPTCHA kiosk | pygame (fullscreen) | — | 192.168.1.12 |
 | `cg-dashboard` | Show Dashboard | `ShowControl/Dashboard/serve.py` | 9000 | 192.168.1.10 |
 
 Playing the Pipes does not yet have a service file; one will be added once the element stub exists.
@@ -88,7 +88,8 @@ python main.py --config settings.json
 ### FundingCAPTCHA
 ```bash
 cd ShowControl/FundingCAPTCHA
-python server.py
+python server.py        # blob server + organiser tools (upload.html, gallery.html)
+python captcha.py       # pygame kiosk (separate terminal or service)
 ```
 
 ---
@@ -101,12 +102,14 @@ Every element has a dev mode — no camera, no LEDs, no servos required.
 |---|---|
 | TreeHouse | `--no-pico` |
 | FlowerBeds | `--mock-camera --no-osc` |
-| FundingCAPTCHA | `--mock-camera` |
+| FundingCAPTCHA | server: `--mock-camera`; client: `--mock-camera` or omit (mouse) |
 
 ```bash
 python main.py --no-pico                    # TreeHouse, no Pico
 python main.py --mock-camera --no-osc       # FlowerBeds, no camera or servos
-python server.py --mock-camera              # FundingCAPTCHA, no depth camera
+python server.py --mock-camera              # FundingCAPTCHA server, fake blobs
+python captcha.py --mock-camera            # FundingCAPTCHA pygame client, connect to mock-camera WS
+python captcha.py                          # FundingCAPTCHA pygame client, mouse-click mode (no server needed)
 ```
 
 ---
@@ -243,9 +246,11 @@ Record the serial numbers in `ShowControl/network.json` under `"firmware"` so th
 
 ### FundingCAPTCHA
 
-- **Hardware:** Orbbec depth camera (USB, optional), Chromium kiosk browser
-- **Services:** Two units — `captcha` (Python server) and `captcha-kiosk` (Chromium browser). The kiosk waits for the server to respond before opening.
-- **Flags:** Edit `/etc/systemd/system/captcha.service` to change `--camera` → `--mock-camera` (no hardware) or remove it entirely (pointer-only mode)
+- **Hardware:** Orbbec depth camera (USB, optional)
+- **Services:** Two units — `captcha` (FastAPI blob server) and `captcha-pygame` (pygame fullscreen kiosk). The pygame unit waits for the server `/health` before starting.
+- **Server flags:** Edit `/etc/systemd/system/captcha.service` to change `--camera` → `--mock-camera` (no hardware)
+- **Client flags:** Edit `/etc/systemd/system/captcha-pygame.service` to change `--camera` → `--mock-camera` or omit for mouse mode
+- **Organiser tools:** Upload photos at `http://192.168.1.12:8080/upload.html`; pair them at `http://192.168.1.12:8080/gallery.html`
 - **Uploads:** Photos saved to `ShowControl/FundingCAPTCHA/uploads/`
 
 ### Show Dashboard


### PR DESCRIPTION
## Summary

- Replaces Chromium kiosk + cage Wayland compositor with `captcha.py` (pygame), eliminating the fragile browser stack on Raspberry Pi
- UpsideDown game fully ported; Rhythm and Keepaway remain JS until their pygame ports are verified and will be deleted game by game
- Background shaders ported from WebGL to moderngl (GLSL 3.3 hybrid: shader behind pygame surface texture); solid-color fallback if moderngl unavailable

## New files

| File | Purpose |
|---|---|
| `captcha.py` | Orchestrator: LOBBY/PLAYING/WIN/LOSE state machine, shuffle bag, WS blob thread, mouse fallback |
| `background.py` | moderngl GLSL shaders composited with pygame surface; fallback to solid color |
| `touch_input.py` | Thin wrapper over existing `ScreenProjector` + `DwellTracker` |
| `audio.py` | numpy triangle-wave synth (C D E G pentatonic — ready for Rhythm port) |
| `games/upsidedown.py` | UpsideDown ported (memory match, photo pairs, countdown timer) |
| `deploy/captcha-pygame.service` | Replaces `captcha-kiosk.service`; waits for server `/health` |
| `docs/adr/0012` | Records pygame-over-browser decision |

## Modified

- `server.py` — removed dead `/api/captcha-settings` endpoint (pygame reads file directly)
- `captcha-settings.json` — removed retired `screen_rect` field
- `requirements.txt` — added `moderngl>=5.8`, `requests>=2.28`
- `docs/operations.md`, `docs/adr/0011` — updated, no stale browser references

## Test plan

- [ ] `python captcha.py` — lobby appears, mouse click starts UpsideDown, pairs match, timer counts down, win/lose transitions work
- [ ] `python server.py --mock-camera` + `python captcha.py --mock-camera` — blob input drives grid taps
- [ ] Background shader visible behind game grid (purple vortex for UpsideDown)
- [ ] On Pi: `captcha-pygame.service` starts after `captcha.service`, fullscreen, no cage/Chromium needed
- [ ] Photo pairs load from `/api/pairs` when server is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)