### PR TITLE
Playing the Pipes: move to Windows mini PC

### DIFF
--- a/ShowControl/Dashboard/index.html
+++ b/ShowControl/Dashboard/index.html
@@ -56,7 +56,7 @@ const ELEMENTS = [
   { id: 'flowerbeds', port: 8765 },
   { id: 'treehouse',  port: 8766 },
   { id: 'captcha',    port: 8080 },
-  { id: 'pipes',      port: null },
+  { id: 'pipes',      port: 8767 },
 ];
 
 const state = {};
@@ -73,8 +73,6 @@ function fmtUptime(ms) {
 }
 
 async function checkElement(el) {
-  if (!el.port) return;  // pipes — always offline until implemented
-
   let online = false;
   try {
     const resp = await fetch(`http://${HOST}:${el.port}/health`, {
@@ -95,9 +93,7 @@ function updateUptimes() {
   ELEMENTS.forEach(el => {
     const s = state[el.id];
     const el2 = document.getElementById(`uptime-${el.id}`);
-    if (el.port === null) {
-      el2.textContent = 'not yet implemented';
-    } else if (s.online && s.since) {
+    if (s.online && s.since) {
       el2.textContent = fmtUptime(Date.now() - s.since);
     } else {
       el2.textContent = 'offline';

--- a/ShowControl/PlayingThePipes/health_server.py
+++ b/ShowControl/PlayingThePipes/health_server.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""
+Playing the Pipes — health server.
+
+Serves GET /health on port 8767 so the Dashboard can monitor this machine.
+Run via NSSM as a Windows background service; see docs/operations.md.
+
+Usage:
+  python health_server.py           # port 8767
+  python health_server.py 8768      # custom port
+"""
+
+import argparse
+import logging
+import socket
+import sys
+
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+app = FastAPI()
+
+log = logging.getLogger("pipes-health")
+
+
+@app.get("/health")
+async def health():
+    return JSONResponse({"ok": True})
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Playing the Pipes health server")
+    parser.add_argument("port", type=int, nargs="?", default=8767)
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    try:
+        local_ip = socket.gethostbyname(socket.gethostname())
+    except Exception:
+        local_ip = "127.0.0.1"
+
+    print(f"Pipes health server:  http://{local_ip}:{args.port}/health")
+    print("Press Ctrl+C to stop.\n")
+
+    uvicorn.run(app, host="0.0.0.0", port=args.port, log_level="warning")
+
+
+if __name__ == "__main__":
+    main()

--- a/ShowControl/PlayingThePipes/requirements.txt
+++ b/ShowControl/PlayingThePipes/requirements.txt
@@ -1,0 +1,2 @@
+fastapi>=0.100
+uvicorn[standard]>=0.23

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -98,9 +98,9 @@ Throughout, the TreeHouse responds to activity across all Elements, updating its
 
 **Status:** Physical construction underway by a teammate.
 
-**What it does:** A Dr. Seuss/Rube Goldberg tangle of water pipes and electrical conduit fitted with valves and switches. Visitors operate the controls to steer a music system running granulators and loop players on a Raspberry Pi (Cycling '74 Max/RNBO). Controls use Tiller Control — visitors change the direction and character of the music, not trigger discrete notes.
+**What it does:** A Dr. Seuss/Rube Goldberg tangle of water pipes and electrical conduit fitted with valves and switches. Visitors operate the controls to steer a music system running granulators and loop players on a Windows mini PC (Cycling '74 Max/RNBO). Controls use Tiller Control — visitors change the direction and character of the music, not trigger discrete notes.
 
-**Hardware path (revised 2026-05-21):** Two Pi Pico microcontrollers read 6 quadrature rotary encoders each (12 total) and send encoder events over USB serial to the Pi. Max reads the Pico serial ports directly and routes encoder deltas into the RNBO patch. RNBO handles all audio DSP and emits `/pipes/activity` to the TreeHouse. See ADR-0014.
+**Hardware path (revised 2026-05-21):** Two Pi Pico microcontrollers read 6 quadrature rotary encoders each (12 total) and send encoder events over USB serial to the Windows mini PC. Max reads the Pico serial ports directly (as COM ports) and routes encoder deltas into the RNBO patch. RNBO handles all audio DSP and emits `/pipes/activity` to the TreeHouse. See ADR-0014.
 
 **OSC output to fabric:** Playing the Pipes is an emitter only — it sends activity signals outward (controls active, engagement level) and does not receive from other Elements. It is a pure sound piece; external OSC input would conflict with the Tiller Control experience.
 

--- a/docs/adr/0014-playingthepipes-encoder-picos.md
+++ b/docs/adr/0014-playingthepipes-encoder-picos.md
@@ -8,7 +8,7 @@ Playing the Pipes has 12 rotary encoders distributed across the physical pipe st
 
 ## Decision
 
-Two Pi Pico microcontrollers (one per section, 6 encoders each) read quadrature rotary encoders and send encoder delta events over USB serial to the Raspberry Pi. Max reads the two serial ports directly and routes events into the RNBO patch.
+Two Pi Pico microcontrollers (one per section, 6 encoders each) read quadrature rotary encoders and send encoder delta events over USB serial to the Windows mini PC. Max reads the two serial ports directly (as Windows COM ports, e.g. `COM3` / `COM4`) and routes events into the RNBO patch.
 
 ## Protocol
 
@@ -41,7 +41,7 @@ All encoder pins use internal pull-ups. Encoder common to Pico GND.
 
 ## Reasons
 
-- Picos sit physically near their encoders; only a USB cable runs back to the Pi
+- Picos sit physically near their encoders; only a USB cable runs back to the Windows mini PC
 - Identical pin layout on both boards simplifies construction and maintenance
 - MicroPython IRQ-based quadrature decoding is robust at human-speed turning rates
 - Consistent with the USB serial pattern established for TreeHouse (ADR-0005, ADR-0010)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -24,8 +24,9 @@ Each show-control element runs as a systemd service with `Restart=always` and `R
 | `captcha` | FundingCAPTCHA | `ShowControl/FundingCAPTCHA/server.py` | 8080 | 192.168.1.12 |
 | `captcha-kiosk` | FundingCAPTCHA kiosk | Chromium (kiosk mode) | — | 192.168.1.12 |
 | `cg-dashboard` | Show Dashboard | `ShowControl/Dashboard/serve.py` | 9000 | 192.168.1.10 |
+| `pipes` | Playing the Pipes | `ShowControl/PlayingThePipes/` + Max/RNBO | 8767 (health) | 192.168.1.13 (Windows) |
 
-Playing the Pipes does not yet have a service file; one will be added once the element stub exists.
+Playing the Pipes runs on a **Windows mini PC** (not Linux). Service supervision uses NSSM or Task Scheduler instead of systemd — see [Playing the Pipes](#playing-the-pipes) below.
 
 ---
 
@@ -328,6 +329,79 @@ sudo udevadm control --reload-rules && sudo udevadm trigger
 
 Record the serial numbers in `ShowControl/network.json` under `"firmware"` so they are not lost.
 
+### Playing the Pipes
+
+- **Machine:** Windows mini PC at `192.168.1.13` — **not Linux**; systemd commands do not apply
+- **Audio engine:** Cycling '74 Max/RNBO (Max for Windows)
+- **USB serial:** Two Pi Picos connect via USB and appear as Windows COM ports (e.g. `COM3` / `COM4`). Configure the port names in Max's `serial` object. COM port numbers are not stable by default — assign fixed numbers in Device Manager (Properties → Port Settings → Advanced → COM Port Number) and record them here once assigned.
+- **Health endpoint:** A standalone Python http server (`ShowControl/PlayingThePipes/health_server.py`) serves `GET /health` on port 8767. This must be running for the Dashboard to show Pipes as online.
+- **Service supervision:** No systemd. Use **NSSM** (Non-Sucking Service Manager) to run both the health server and Max as Windows services with auto-restart. Alternatively, Task Scheduler with `On startup` trigger.
+
+**First-time service install (NSSM):**
+
+Download NSSM from https://nssm.cc, place `nssm.exe` somewhere on `PATH`, then run once in an admin PowerShell:
+
+```powershell
+nssm install pipes-health python
+nssm set pipes-health AppParameters "C:\CommunityGarden\ShowControl\PlayingThePipes\health_server.py"
+nssm set pipes-health AppDirectory  "C:\CommunityGarden\ShowControl\PlayingThePipes"
+nssm set pipes-health AppStdout     "C:\logs\pipes-health.log"
+nssm set pipes-health AppStderr     "C:\logs\pipes-health.log"
+nssm set pipes-health Start         SERVICE_AUTO_START
+nssm start pipes-health
+```
+
+**Manual startup (dev):**
+
+```powershell
+cd ShowControl\PlayingThePipes
+pip install -r requirements.txt
+python health_server.py
+
+# Max — open the patch manually or via CLI
+"C:\Program Files\Cycling '74\Max 9\Max.exe" PlayingThePipes.maxpat
+```
+
+**Service management (NSSM):**
+
+```powershell
+# Status
+nssm status pipes-health
+
+# Restart
+nssm restart pipes-health
+
+# Logs
+Get-Content C:\logs\pipes-health.log -Tail 50
+```
+
+**Updating the software:**
+
+```powershell
+cd C:\CommunityGarden
+git pull
+# Restart health server service
+nssm restart pipes-health
+# Reload Max patch manually
+```
+
+**COM port identification (first-time setup):**
+
+```powershell
+# List all COM ports
+[System.IO.Ports.SerialPort]::GetPortNames()
+# Or: Device Manager → Ports (COM & LPT)
+```
+
+Plug Picos in one at a time, note which COM port appears, label each Pico and record here:
+
+| Pico | Board ID | COM port |
+|------|----------|----------|
+| Board 0 | 0 | TBD |
+| Board 1 | 1 | TBD |
+
+---
+
 ### FundingCAPTCHA
 
 - **Hardware:** Orbbec depth camera (USB, optional), Chromium kiosk browser
@@ -380,7 +454,7 @@ sudo udevadm control --reload-rules && sudo udevadm trigger
 
 ## Open questions / future work
 
-- **Playing the Pipes**: once the element stub exists, add `ShowControl/PlayingThePipes/deploy/pipes.service` following the same pattern and add it to `scripts/install-services.sh`.
+- **Playing the Pipes**: runs on Windows — needs `ShowControl/PlayingThePipes/health_server.py` (Python/FastAPI, port 8767), NSSM service config, and Max patch wired to health state. `scripts/install-services.sh` does not cover this machine; a separate Windows setup script or NSSM config export is needed.
 - **Multi-machine deploy**: the install script currently runs locally. A simple Ansible playbook or `pdsh` wrapper would let a single operator re-deploy all machines simultaneously.
 - **Health monitoring**: `Restart=always` handles crashes but doesn't alert operators. A lightweight watchdog that posts to a Slack/Discord webhook on repeated restarts would improve unattended operation.
 - **Orbbec SDK version pinning**: `pyorbbecsdk2` must match the SDK `.so` installed on the host. Document the exact version pairing per machine if they diverge.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -12,6 +12,7 @@ For on-site crew. See [Operations Guide](operations.md) for full service managem
 | TreeHouse | 192.168.1.10 | http://192.168.1.10:8766 (visualizer) |
 | FlowerBeds | 192.168.1.11 | http://192.168.1.11:8765 (visualizer) |
 | FundingCAPTCHA | 192.168.1.12 | http://192.168.1.12:8080 |
+| Playing the Pipes | 192.168.1.13 (Windows) | http://192.168.1.13:8767/health |
 
 ---
 
@@ -135,6 +136,27 @@ See [Operations Guide — FundingCAPTCHA](operations.md#fundingcaptcha) for more
 
 ---
 
+### Playing the Pipes
+
+**Machine:** `192.168.1.13` (Windows mini PC) | **Health:** http://192.168.1.13:8767/health
+
+Max/RNBO patch runs the audio engine. Two Pi Picos connect via USB and appear as COM ports.
+
+**First-time provisioning (once per machine):**
+
+1. Assign fixed COM port numbers to each Pico in Device Manager → Ports (COM & LPT) → Properties → Port Settings → Advanced → COM Port Number. Record them in the [Operations Guide — Playing the Pipes](operations.md#playing-the-pipes) table.
+2. Install Python deps: `pip install -r ShowControl\PlayingThePipes\requirements.txt`
+3. Install NSSM and register the health server service (see Operations Guide).
+4. Open `ShowControl\PlayingThePipes\PlayingThePipes.maxpat` in Max and confirm encoder events arrive.
+
+**Startup (daily):**
+
+Services start automatically via NSSM. Open Max manually if the patch is not set to auto-launch.
+
+See [Operations Guide — Playing the Pipes](operations.md#playing-the-pipes) for service management detail.
+
+---
+
 ### Dashboard
 
 **URL:** http://192.168.1.10:9000 — runs on the TreeHouse machine.
@@ -158,6 +180,14 @@ sudo systemctl restart <service>  # restart if needed
 ```
 
 Service names: `flowerbeds` · `treehouse` · `captcha` · `cg-dashboard`
+
+For **Playing the Pipes** (Windows): open a PowerShell window on the mini PC and run:
+
+```powershell
+nssm status pipes-health
+nssm restart pipes-health
+Get-Content C:\logs\pipes-health.log -Tail 50
+```
 
 ### FlowerBeds flowers not moving
 


### PR DESCRIPTION
## Summary

- Playing the Pipes host platform changes from Raspberry Pi to a Windows mini PC (192.168.1.13)
- All docs updated: PRD, ADR-0014, `setup.md`, `operations.md` — Pi references replaced, COM port workflow added
- Dashboard wired up: pipes port was `null` (always offline); now `8767` with full health polling
- New `ShowControl/PlayingThePipes/health_server.py` — FastAPI `/health` endpoint, NSSM-ready
- New `ShowControl/PlayingThePipes/requirements.txt` — `fastapi` + `uvicorn` only

## Still needed on the Windows machine (not in this PR)

- [ ] Assign fixed COM port numbers to both Picos in Device Manager and fill in the ops doc table
- [ ] Run NSSM install commands from `operations.md` to register `pipes-health` as an auto-start service
- [ ] Update Max `serial` objects to use the assigned COM port names
- [ ] Confirm `GET http://192.168.1.13:8767/health` returns `{"ok": true}` -> Dashboard shows Pipes green

## Test plan

- [ ] `python health_server.py` starts without error; `curl http://localhost:8767/health` returns `{"ok": true}`
- [ ] Dashboard at `http://192.168.1.10:9000` shows Pipes as offline (not "not yet implemented") until health server is running on the Pipes machine

Generated with [Claude Code](https://claude.com/claude-code)