### PR TITLE
Funding CAPTCHA Tuning

### DIFF
--- a/IIVision/blob_tracker.py
+++ b/IIVision/blob_tracker.py
@@ -186,7 +186,6 @@ class Calibrator:
         frames = np.stack(self._frames, axis=0).astype(np.uint16)  # (N, H*W)
         valid = (
             (frames >= self._config.min_depth_mm)
-            & (frames <= self._config.max_depth_mm)
         )
         num_valid = valid.sum(axis=0)  # (H*W,)
         valid_mask = num_valid >= _MIN_FRAMES_VALID

--- a/IIVision/blob_tracker.py
+++ b/IIVision/blob_tracker.py
@@ -47,7 +47,6 @@ class FramePacket:
 @dataclass
 class CalibrationConfig:
     min_depth_mm: int = 50
-    max_depth_mm: int = 6000
 
 
 @dataclass
@@ -184,9 +183,11 @@ class Calibrator:
                 f"Calibrator needs {self._num_frames} frames, has {len(self._frames)}"
             )
         frames = np.stack(self._frames, axis=0).astype(np.uint16)  # (N, H*W)
-        valid = (
-            (frames >= self._config.min_depth_mm)
-        )
+        # No upper cap: a far wall past DetectionConfig.max_depth_mm is still
+        # a real background — clipping it here makes those pixels invalid and
+        # punches holes in the foreground when people stand in front. Flaky
+        # pixels are handled downstream by the noise_floor (IQR) threshold.
+        valid = frames >= self._config.min_depth_mm
         num_valid = valid.sum(axis=0)  # (H*W,)
         valid_mask = num_valid >= _MIN_FRAMES_VALID
 

--- a/ShowControl/FundingCAPTCHA/captcha-settings.json
+++ b/ShowControl/FundingCAPTCHA/captcha-settings.json
@@ -9,7 +9,7 @@
   },
 
   "depth_slabs": [
-    {"near_mm": 800, "far_mm": 2000, "slab_id": 0}
+    {"near_mm": 500, "far_mm": 3000, "slab_id": 0}
   ],
 
   "slab_styles": {
@@ -46,7 +46,7 @@
     "width":   640,
     "height":  400,
     "fps":     10,
-    "pos_cm":  [0, 0, 50],
-    "rotation": {"pitch": -30, "yaw": 0, "roll": 0}
+    "pos_cm":  [0, 0, 78],
+    "rotation": {"pitch": -24, "yaw": 0, "roll": 0}
   }
 }


### PR DESCRIPTION
## Summary
- **`IIVision/blob_tracker.py`** — Drop `CalibrationConfig.max_depth_mm`. The 6000mm default cap conflated *sensor trustworthy range* with *application tracking volume*. When the back wall sat past it, wall pixels got `valid=False` during calibration → `bg_valid` False at runtime → no foreground for anyone standing in front of those pixels (holes in the silhouette). Flaky pixels are already handled by the IQR-based `noise_floor` threshold downstream, so removing the cap doesn't reintroduce noise-flicker risk.
- **`ShowControl/FundingCAPTCHA/captcha-settings.json`** — Update installed camera pose (`pos_cm` z 50→78, pitch -30→-24) and widen tracking slab to 500–3000mm to match the install footprint.

## Test plan
- [x] `pytest IIVision/test_detect_foreground.py` — 6 passed
- [ ] Run FundingCAPTCHA in the install room (back wall >6m); confirm silhouette has no holes where the wall is visible behind the player
- [ ] Confirm noisy/flaky pixels still don't false-trigger as foreground in empty-room baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)