### PR TITLE
BodyCaptcha editor: standalone .exe + merge tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ layout_calibrated.json
 
 # Local calibration data (machine-specific, written by touch_test_pygame.py)
 captcha-settings.local.json
+
+# BodyCaptcha editor build artifacts (PyInstaller output)
+ShowControl/FundingCAPTCHA/distribution/dist/
+ShowControl/FundingCAPTCHA/distribution/build_work/

--- a/ShowControl/FundingCAPTCHA/bodycaptcha_editor.py
+++ b/ShowControl/FundingCAPTCHA/bodycaptcha_editor.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import json
+import sys
 from copy import deepcopy
 from pathlib import Path
 
 import pygame
 
-_DIR    = Path(__file__).parent
+# When frozen by PyInstaller, data lives next to the .exe, not inside the
+# unpacked bundle (which is a temp dir and read-only across launches).
+if getattr(sys, "frozen", False):
+    _DIR = Path(sys.executable).parent
+else:
+    _DIR = Path(__file__).parent
 _LEVELS = _DIR / "bodycaptcha-levels.json"
 _IMAGES = _DIR / "images"
 
@@ -74,8 +80,13 @@ def _load() -> list[dict]:
     return [deepcopy(DEFAULT_LEVEL)]
 
 
+def _sort_key(lv: dict) -> tuple[str, str]:
+    return (lv.get("image") or "", lv.get("prompt") or "")
+
+
 def _save(levels: list[dict]) -> None:
-    _LEVELS.write_text(json.dumps(levels, indent=2) + "\n")
+    ordered = sorted(levels, key=_sort_key)
+    _LEVELS.write_text(json.dumps(ordered, indent=2) + "\n")
 
 
 def _wrap(text: str, max_chars: int) -> list[str]:
@@ -380,6 +391,9 @@ class Editor:
         if self._editing:
             self._lv["prompt"] = self._buf
             self._editing = False
+        current = self._lv
+        self._levels.sort(key=_sort_key)
+        self._idx = self._levels.index(current)
         _save(self._levels)
         self._dirty = False
         self._flash("Saved!")

--- a/ShowControl/FundingCAPTCHA/distribution/README.md
+++ b/ShowControl/FundingCAPTCHA/distribution/README.md
@@ -1,0 +1,76 @@
+# BodyCaptcha Editor — Distribution Workflow
+
+Tooling for shipping [`../bodycaptcha_editor.py`](../bodycaptcha_editor.py) to teammates who aren't git-savvy, and merging their level contributions back into the repo.
+
+## One-time setup
+
+```
+pip install pyinstaller pygame pillow
+```
+
+## Build the editor
+
+```
+python build.py
+```
+
+Produces `dist/BodyCaptchaEditor.exe` — a single-file Windows executable that bundles Python, pygame, and Pillow (~50MB). The editor's data paths (`bodycaptcha-levels.json`, `images/`) resolve relative to the `.exe` location at runtime, so each teammate's installation is self-contained.
+
+Re-run after any change to `bodycaptcha_editor.py`.
+
+## Package the teammate zip
+
+```
+python package.py
+```
+
+Produces a single universal `dist/BodyCaptchaEditor.zip` containing:
+
+- `BodyCaptchaEditor.exe`
+- starter `bodycaptcha-levels.json`
+- empty `images/` folder with a README telling the teammate to create their own subfolder
+- `README.txt` (a copy of [`TEAMMATE_README.txt`](TEAMMATE_README.txt))
+
+Send the same zip to everyone. **Tell each person individually what subfolder name to use** under `images/` (`alice`, `bob`, etc.) — one unique name per person so contributor merges don't collide on image paths. The teammate README is firm about creating the subfolder, but the name itself has to come from you.
+
+When the editor changes, rebuild and resend the same single zip.
+
+## Merge contributions back
+
+When a teammate sends back their zip:
+
+1. Unzip somewhere outside the repo (e.g. `~/Downloads/from-alice/BodyCaptchaEditor-alice/`).
+2. Copy their `images/alice/` folder into [`../images/`](../images/) in the repo.
+3. Merge their levels into the master JSON:
+
+```
+python merge_levels.py ../bodycaptcha-levels.json \
+    ~/Downloads/from-alice/BodyCaptchaEditor-alice/bodycaptcha-levels.json \
+    -o ../bodycaptcha-levels.json
+```
+
+Multiple contributors in one shot:
+
+```
+python merge_levels.py ../bodycaptcha-levels.json \
+    from-alice/bodycaptcha-levels.json \
+    from-bob/bodycaptcha-levels.json \
+    -o ../bodycaptcha-levels.json
+```
+
+The script:
+
+- Identifies levels by `(image, prompt)`.
+- Silently deduplicates exact matches.
+- Reports conflicts (same identity, different cells/grid/timer) to stderr. **First source wins** — since master is listed first, the master always beats contributors on a tie; you fix the rest by hand and re-run.
+- Writes output sorted by `(image, prompt)` for clean git diffs.
+
+Add `--dry-run` to see the conflict report without writing anything. Exit code is non-zero if any conflicts were detected, so the merge is easy to gate in a script or CI step.
+
+## Conflict prevention
+
+The per-teammate-subfolder convention (`images/<name>/`) means contributors never reference the same image path, so `(image, prompt)` identities can't collide. Real conflicts should only happen if a teammate touches an image outside their subfolder — which the README tells them not to do.
+
+## When the editor itself changes
+
+There's no auto-update mechanism. Re-run `build.py` + `package.py` and resend the zip. Ask teammates to copy their `images/<name>/` and `bodycaptcha-levels.json` from their old folder into the new one before launching.

--- a/ShowControl/FundingCAPTCHA/distribution/TEAMMATE_README.txt
+++ b/ShowControl/FundingCAPTCHA/distribution/TEAMMATE_README.txt
@@ -1,0 +1,66 @@
+=========================================================
+ BodyCaptcha Level Editor -- Teammate Quick Start
+=========================================================
+
+WHAT THIS IS
+------------
+A tiny editor for building "select all squares containing X"
+levels for the Funding CAPTCHA game.
+
+GETTING STARTED
+---------------
+1. Unzip this folder somewhere on your computer (Desktop is fine).
+
+2. In the images/ folder, create a SUBFOLDER named after
+   yourself (lowercase, no spaces). Charlie will tell you what
+   to call it -- usually just your first name.
+   Examples:  images/alice/   images/bob/   images/charlie/
+
+3. Drop your image files into YOUR subfolder.
+   - .jpg, .jpeg, .png, and .webp all work.
+   - Nested subfolders are fine (e.g. images/alice/animals/).
+
+4. Double-click BodyCaptchaEditor.exe to launch the editor.
+   - On first launch, Windows may warn about an unrecognized app.
+     Click "More info" -> "Run anyway".
+
+USING THE EDITOR
+----------------
+- PICK IMAGE in the sidebar -> choose an image for the current level.
+- PROMPT (or press E) -> type the question text.
+- Click cells in the grid to mark them as the "correct" answers.
+- Use the +/- buttons to adjust difficulty, grid size, and timer.
+- < PREV / NEXT > (or Left/Right arrows) -> navigate levels.
+- + NEW LEVEL (or Ctrl+N) -> add a level.
+- SAVE (or Ctrl+S) -> writes your work to bodycaptcha-levels.json
+  next to the .exe. Do this often.
+
+KEYBOARD SHORTCUTS
+------------------
+  E           edit the prompt text
+  + / -       change difficulty
+  Up / Down   change timer (+/- 5s)
+  Left/Right  prev / next level
+  Ctrl+S      save
+  Ctrl+N      new level
+  Ctrl+C      clear cell selections on the current level
+  Ctrl+Del    delete the current level
+  Esc         close the image picker
+
+NOTES
+-----
+- If you add new images while the editor is open, close and
+  reopen it so the picker re-scans the images folder.
+- ONLY USE IMAGES IN YOUR OWN SUBFOLDER. If you reference an
+  image outside your folder, your levels may conflict with
+  someone else's when contributions are merged.
+
+WHEN YOU'RE DONE
+----------------
+1. Hit SAVE one more time (just to be sure).
+2. Close the editor.
+3. Right-click the WHOLE folder -> "Send to" ->
+   "Compressed (zipped) folder".
+4. Email or upload that zip back to Charlie.
+
+Thanks for contributing levels!

--- a/ShowControl/FundingCAPTCHA/distribution/build.py
+++ b/ShowControl/FundingCAPTCHA/distribution/build.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Build a standalone BodyCaptchaEditor executable using PyInstaller.
+
+Output: dist/BodyCaptchaEditor.exe (Windows) — a single-file binary that
+bundles Python, pygame, and Pillow. The editor reads/writes data files
+next to the .exe at runtime (see frozen-path handling in
+bodycaptcha_editor.py).
+
+Run after any change to bodycaptcha_editor.py:
+    pip install pyinstaller
+    python build.py
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+HERE   = Path(__file__).resolve().parent
+ROOT   = HERE.parent
+EDITOR = ROOT / "bodycaptcha_editor.py"
+DIST   = HERE / "dist"
+WORK   = HERE / "build_work"
+
+
+def main() -> int:
+    if not EDITOR.exists():
+        print(f"ERROR: editor not found at {EDITOR}", file=sys.stderr)
+        return 1
+
+    try:
+        import PyInstaller  # noqa: F401
+    except ImportError:
+        print("PyInstaller is not installed. Run:", file=sys.stderr)
+        print("    pip install pyinstaller", file=sys.stderr)
+        return 1
+
+    for d in (DIST, WORK):
+        if d.exists():
+            shutil.rmtree(d)
+
+    cmd = [
+        sys.executable, "-m", "PyInstaller",
+        "--name", "BodyCaptchaEditor",
+        "--onefile",
+        "--distpath", str(DIST),
+        "--workpath", str(WORK),
+        "--specpath", str(WORK),
+        "--collect-submodules", "pygame",
+        "--hidden-import", "PIL.Image",
+        str(EDITOR),
+    ]
+    print("Running:", " ".join(cmd))
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        return result.returncode
+
+    suffix = ".exe" if sys.platform == "win32" else ""
+    exe = DIST / f"BodyCaptchaEditor{suffix}"
+    print(f"\nBuilt: {exe}")
+    print("Next: `python package.py` to make a shippable zip.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ShowControl/FundingCAPTCHA/distribution/merge_levels.py
+++ b/ShowControl/FundingCAPTCHA/distribution/merge_levels.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Merge contributor BodyCaptcha level JSONs into the master JSON.
+
+Identity is (image, prompt). Exact duplicates are silently deduplicated.
+Levels with the same identity but differing fields are reported as
+conflicts; the first source wins (so the master always beats contributors
+when it appears first on the command line).
+
+Output is sorted by (image, prompt) so future merges produce clean diffs.
+
+Examples:
+    python merge_levels.py ../bodycaptcha-levels.json contrib/alice.json \\
+        -o ../bodycaptcha-levels.json
+
+    python merge_levels.py ../bodycaptcha-levels.json contrib/*.json \\
+        --dry-run
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _load(path: Path) -> list[dict]:
+    try:
+        data = json.loads(path.read_text())
+    except Exception as e:
+        print(f"ERROR: failed to read {path}: {e}", file=sys.stderr)
+        sys.exit(2)
+    if not isinstance(data, list):
+        print(f"ERROR: {path} is not a JSON array", file=sys.stderr)
+        sys.exit(2)
+    return data
+
+
+def _identity(level: dict) -> tuple[str, str]:
+    return (level.get("image") or "", level.get("prompt") or "")
+
+
+def _normalize(level: dict) -> dict:
+    out = dict(level)
+    if "valid_cells" in out:
+        out["valid_cells"] = sorted(tuple(c) for c in out["valid_cells"])
+    if "grid" in out:
+        out["grid"] = tuple(out["grid"])
+    return out
+
+
+def _equiv(a: dict, b: dict) -> bool:
+    return _normalize(a) == _normalize(b)
+
+
+def merge(sources: list[tuple[str, list[dict]]]) -> tuple[list[dict], list[str]]:
+    """Merge level lists in source order; first occurrence of each identity wins.
+
+    Returns (merged_levels_sorted, conflict_messages).
+    """
+    seen: dict[tuple[str, str], tuple[str, dict]] = {}
+    conflicts: list[str] = []
+    for source_name, levels in sources:
+        for lv in levels:
+            key = _identity(lv)
+            if key in seen:
+                prev_source, prev_level = seen[key]
+                if _equiv(prev_level, lv):
+                    continue
+                conflicts.append(
+                    f"CONFLICT  image={key[0]!r}  prompt={key[1]!r}\n"
+                    f"  kept from : {prev_source}  {json.dumps(_diff_fields(prev_level))}\n"
+                    f"  ignored   : {source_name}  {json.dumps(_diff_fields(lv))}"
+                )
+            else:
+                seen[key] = (source_name, lv)
+    merged = sorted((lv for _, lv in seen.values()), key=_identity)
+    return merged, conflicts
+
+
+def _diff_fields(lv: dict) -> dict:
+    """Subset of fields useful for conflict reporting (excludes the identity keys)."""
+    return {k: v for k, v in lv.items() if k not in ("image", "prompt")}
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Merge BodyCaptcha level JSONs.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="Exit code is non-zero if any conflicts were detected.",
+    )
+    ap.add_argument("master", help="Master levels JSON (read first; wins ties)")
+    ap.add_argument("contributors", nargs="+", help="Contributor levels JSONs")
+    ap.add_argument("-o", "--output",
+                    help="Write merged JSON to this path (default: stdout)")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Report only; do not write output")
+    args = ap.parse_args(argv)
+
+    sources: list[tuple[str, list[dict]]] = []
+    for path_str in [args.master] + args.contributors:
+        path = Path(path_str)
+        sources.append((path.name, _load(path)))
+
+    merged, conflicts = merge(sources)
+
+    total_in = sum(len(lv) for _, lv in sources)
+    print(
+        f"Merged {total_in} input levels from {len(sources)} source(s) "
+        f"-> {len(merged)} unique ({len(conflicts)} conflict(s)).",
+        file=sys.stderr,
+    )
+    for c in conflicts:
+        print(c, file=sys.stderr)
+
+    if args.dry_run:
+        return 1 if conflicts else 0
+
+    text = json.dumps(merged, indent=2) + "\n"
+    if args.output:
+        Path(args.output).write_text(text)
+        print(f"Wrote {args.output}", file=sys.stderr)
+    else:
+        sys.stdout.write(text)
+
+    return 1 if conflicts else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ShowControl/FundingCAPTCHA/distribution/package.py
+++ b/ShowControl/FundingCAPTCHA/distribution/package.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Build the universal teammate distribution zip for the BodyCaptcha editor.
+
+Requires `build.py` to have run first (the .exe must exist in dist/).
+
+Run:
+    python package.py
+
+Output:
+    dist/BodyCaptchaEditor.zip
+
+Zip layout:
+    BodyCaptchaEditor/
+        BodyCaptchaEditor.exe
+        bodycaptcha-levels.json     (one blank starter level)
+        images/
+            README.txt              (tells the teammate to make a subfolder)
+        README.txt                  (teammate quick-start)
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+import zipfile
+from pathlib import Path
+
+HERE   = Path(__file__).resolve().parent
+DIST   = HERE / "dist"
+EXE    = DIST / "BodyCaptchaEditor.exe"
+README = HERE / "TEAMMATE_README.txt"
+
+DEFAULT_LEVELS = [{
+    "prompt": "Select all ...",
+    "image": None,
+    "difficulty": 1,
+    "grid": [3, 3],
+    "valid_cells": [],
+    "timer_s": 40,
+}]
+
+IMAGES_README = """\
+This is the images folder.
+
+Before adding any images, create a SUBFOLDER inside this one
+named after yourself (lowercase, no spaces). Charlie will have
+told you what to call it -- usually your first name.
+
+Examples:
+    images/alice/
+    images/bob/
+    images/charlie/
+
+Then drop your image files (.jpg / .jpeg / .png / .webp) into
+your subfolder. The editor will pick them up automatically.
+
+DO NOT skip this step. Two contributors using the same image
+filename ("cat.jpg") will collide when their work is merged
+together -- unless each one is tucked inside their own subfolder.
+"""
+
+
+def main() -> int:
+    if not EXE.exists():
+        print(f"ERROR: editor not built -- expected {EXE}", file=sys.stderr)
+        print("Run `python build.py` first.", file=sys.stderr)
+        return 1
+    if not README.exists():
+        print(f"ERROR: missing {README}", file=sys.stderr)
+        return 1
+
+    staging = DIST / "BodyCaptchaEditor"
+    if staging.exists():
+        shutil.rmtree(staging)
+    staging.mkdir(parents=True)
+
+    shutil.copy2(EXE, staging / EXE.name)
+    shutil.copy2(README, staging / "README.txt")
+    (staging / "bodycaptcha-levels.json").write_text(
+        json.dumps(DEFAULT_LEVELS, indent=2) + "\n"
+    )
+    images = staging / "images"
+    images.mkdir()
+    (images / "README.txt").write_text(IMAGES_README)
+
+    zip_path = DIST / "BodyCaptchaEditor.zip"
+    if zip_path.exists():
+        zip_path.unlink()
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for p in sorted(staging.rglob("*")):
+            zf.write(p, p.relative_to(staging.parent))
+
+    print(f"Built: {zip_path}")
+    print("Send this zip to everyone. Tell each person what subfolder name")
+    print("to use under images/ -- one unique name per person so contributor")
+    print("merges don't collide on image paths.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Lets non-git-savvy teammates run the BodyCaptcha level editor as a single Windows `.exe`, add images, build levels, and zip the result back -- no Python install, no git.
- Adds `merge_levels.py` to fold contributor JSONs back into the master, dedup-ing exact matches and surfacing real conflicts so collisions don't get committed silently.
- Patches `bodycaptcha_editor.py` so PyInstaller-frozen builds resolve `bodycaptcha-levels.json` / `images/` next to the `.exe` (not inside the bundle's read-only temp dir), and so saved level JSONs are sorted by `(image, prompt)` for clean diffs.

## Workflow it enables
```
pip install pyinstaller pygame pillow         # one-time
python build.py                               # produces dist/BodyCaptchaEditor.exe
python package.py                             # produces dist/BodyCaptchaEditor.zip
# ...ship the same zip to everyone; tell each person their images/ subfolder name...
python merge_levels.py ../bodycaptcha-levels.json from-alice/bodycaptcha-levels.json -o ../bodycaptcha-levels.json
```

See [`ShowControl/FundingCAPTCHA/distribution/README.md`](../tree/fc-bc-editor-distribution/ShowControl/FundingCAPTCHA/distribution/README.md) for the full flow.

## Test plan
- [x] `merge_levels.py` smoke-tested against a master + two synthetic contributor JSONs (one with an exact duplicate, one with a real conflict) -- dedupes the duplicate, reports the conflict, master wins, output is sorted, exit code is non-zero on conflict.
- [x] `build.py` already produced a working `dist/BodyCaptchaEditor.exe` locally.
- [ ] Launch the bundled `.exe` from an unzipped folder on a fresh path, confirm it reads/writes `bodycaptcha-levels.json` and `images/` from that folder (not from the bundle temp dir).
- [ ] Run `package.py`, unzip the result on a second machine without Python installed, confirm the editor launches and the image picker sees files dropped into `images/<name>/`.
- [ ] Make a few edits, save, and verify the on-disk JSON is sorted by `(image, prompt)`.
- [ ] Send a real teammate the zip and run a real merge cycle end-to-end.

## Notes
- `dist/` and `build_work/` are gitignored -- only the source files under `distribution/` are committed.
- No auto-update mechanism: editor changes require re-running `build.py` + `package.py` and resending the zip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)