### PR TITLE
FundingCAPTCHA Games share a UI shell — billboard prompt + maximal grid

### DIFF
--- a/ShowControl/FundingCAPTCHA/app.py
+++ b/ShowControl/FundingCAPTCHA/app.py
@@ -526,9 +526,8 @@ def main() -> None:
     font_big = pygame.font.SysFont("monospace", 36, bold=True)
     font_sml = pygame.font.SysFont("monospace", 22)
 
-    # HUD width matches games/grid.py constant
-    from games.grid import HUD_W
-    game_w = WW - HUD_W
+    # Full-screen game area (no HUD column — ADR-0019)
+    game_w = WW
 
     # ── Games ─────────────────────────────────────────────────────────────────
     games      = _load_games(settings)

--- a/ShowControl/FundingCAPTCHA/games/body_keepaway.py
+++ b/ShowControl/FundingCAPTCHA/games/body_keepaway.py
@@ -1,4 +1,4 @@
-"""BodyKeepaway — silhouette survival game (ADR-0013)."""
+"""BodyKeepaway — silhouette survival game (ADR-0013, ADR-0019)."""
 from __future__ import annotations
 
 import json
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 from games.grid import (
     Grid,
     BLACK, WHITE, DK_GREY, MID_GREY, LT_GREY, GREEN, YELLOW, RED, BLUE,
-    HUD_W, hud_font, draw_hud_label, draw_progress_bar,
+    hud_font, top_bar_height, draw_top_bar, draw_center_text,
 )
 from body_grid import BodyGridActivator, BodyGridConfig, SlabConfig, CellActivations
 
@@ -31,7 +31,6 @@ WIN_COLOR      = (0, 220, 80)
 _WIN_FLASH_S = 0.5
 _WIN_FINAL_S = 2.0
 _BLOWUP_S    = 2.8
-_TIMER_BAR_H = 10
 
 
 class _State(Enum):
@@ -208,14 +207,6 @@ def _draw_stick_figure(surf: pygame.Surface, cx: int, cy: int,
     pygame.draw.line(surf, color, (cx, body_bot), (cx + leg_len, body_bot + leg_len), lw)
 
 
-def _lerp_color(a: tuple, b: tuple, t: float) -> tuple:
-    return (
-        int(a[0] + t * (b[0] - a[0])),
-        int(a[1] + t * (b[1] - a[1])),
-        int(a[2] + t * (b[2] - a[2])),
-    )
-
-
 class BodyKeepawayGame:
     def __init__(self, settings: dict) -> None:
         self._settings   = settings
@@ -230,10 +221,6 @@ class BodyKeepawayGame:
         WW, WH       = pygame.display.get_surface().get_size()
         self._WW     = WW
         self._WH     = WH
-        self._font_big   = hud_font(22)
-        self._font_sml   = hud_font(16)
-        self._font_huge  = pygame.font.SysFont("monospace", 56, bold=True)
-        self._font_taunt = pygame.font.SysFont("monospace", 28, bold=True)
 
         self._level_idx:   int                      = 0
         self._grid:        Grid | None              = None
@@ -421,22 +408,26 @@ class BodyKeepawayGame:
             return
 
         surf.fill(BLACK)
-        game_w = self._WW - HUD_W
+        bounds = g.bounds_rect
+        bar_h  = g.top_reserve
+        prompt = self._level.get("prompt", "")  # optional — Keepaway levels have none today
 
         if self._state == _State.BLOWUP:
             self._draw_confetti(surf)
-            self._draw_taunt(surf, game_w)
-            self._draw_hud(surf)
+            draw_center_text(surf, self._taunt, RED,
+                             self._WW, bar_h, self._WH, max_font=120)
+            draw_top_bar(surf, self._WW, bar_h, prompt, None)
             return
 
-        # Silhouette overlay
+        # Silhouette overlay (faint), scaled to grid bounds
         if self._foreground is not None:
             slab_color = tuple(self._settings.get("slab_styles", {})
                                .get("0", {}).get("color", [0, 220, 100]))
             sil = _foreground_surf(self._foreground, self._slabs_cfg,
-                                   self._roi, slab_color, game_w, self._WH)
+                                   self._roi, slab_color,
+                                   bounds.width, bounds.height)
             sil.set_alpha(60)
-            surf.blit(sil, (0, 0))
+            surf.blit(sil, bounds.topleft)
 
         # Runner cell highlights
         tile = pygame.Surface((g.cell_size, g.cell_size), pygame.SRCALPHA)
@@ -463,61 +454,51 @@ class BodyKeepawayGame:
                 py = int(gy + d.y * g.cell_size + g.cell_size * 0.5)
                 _draw_stick_figure(surf, px, py, g.cell_size, DEFENDER_COLOR)
 
-        # Timer bar across top of game area
-        if self._state in (_State.GRACE, _State.PLAYING, _State.NO_RUNNERS):
-            self._draw_timer_bar(surf, game_w)
-
-        # State overlays
+        # State overlays (centered text inside grid area)
         if self._state == _State.GRACE:
-            self._draw_grace_overlay(surf, game_w)
+            remaining = max(0.0, self._grace_s - self._state_t)
+            n         = math.ceil(remaining)
+            label     = str(n) if n > 0 else "GO!"
+            draw_center_text(surf, label, WHITE,
+                             self._WW, bar_h, self._WH, max_font=180)
         elif self._state == _State.NO_RUNNERS:
-            self._draw_no_runners_overlay(surf, game_w)
+            self._draw_no_runners_overlay(surf, bar_h)
+        elif self._state == _State.WIN_FLASH:
+            draw_center_text(surf, "LEVEL CLEAR!", GREEN,
+                             self._WW, bar_h, self._WH, max_font=140)
         elif self._state == _State.WIN_FINAL:
-            self._draw_win_overlay(surf, game_w)
+            draw_center_text(surf, "YOU SURVIVED", WHITE,
+                             self._WW, bar_h, self._WH, max_font=140)
 
-        self._draw_hud(surf)
-
-    def _draw_timer_bar(self, surf: pygame.Surface, game_w: int) -> None:
-        remaining = max(0.0, self._survive_s - self._elapsed)
-        pct       = remaining / max(self._survive_s, 0.001)
-        if pct > 0.5:
-            col = _lerp_color(YELLOW, GREEN, (pct - 0.5) * 2)
+        # Top bar: prompt (optional) + level timer
+        if self._state in (_State.GRACE, _State.PLAYING, _State.NO_RUNNERS):
+            remaining: float | None = max(0.0, self._survive_s - self._elapsed)
         else:
-            col = _lerp_color(RED, YELLOW, pct * 2)
-        pygame.draw.rect(surf, MID_GREY, (0, 0, game_w, _TIMER_BAR_H))
-        pygame.draw.rect(surf, col, (0, 0, max(0, int(game_w * pct)), _TIMER_BAR_H))
+            remaining = None
+        draw_top_bar(surf, self._WW, bar_h, prompt, remaining, timer_warn_s=5.0)
 
-    def _draw_grace_overlay(self, surf: pygame.Surface, game_w: int) -> None:
-        remaining = max(0.0, self._grace_s - self._state_t)
-        n         = math.ceil(remaining)
-        label     = str(n) if n > 0 else "GO!"
-        t = self._font_huge.render(label, True, WHITE)
-        surf.blit(t, t.get_rect(center=(game_w // 2, self._WH // 2)))
-
-    def _draw_no_runners_overlay(self, surf: pygame.Surface, game_w: int) -> None:
-        overlay = pygame.Surface((game_w, self._WH), pygame.SRCALPHA)
+    def _draw_no_runners_overlay(self, surf: pygame.Surface, bar_h: int) -> None:
+        area_h  = self._WH - bar_h
+        overlay = pygame.Surface((self._WW, area_h), pygame.SRCALPHA)
         overlay.fill((0, 0, 0, 120))
-        surf.blit(overlay, (0, 0))
+        surf.blit(overlay, (0, bar_h))
 
-        t1 = self._font_huge.render("GET ON THE FIELD", True, YELLOW)
-        surf.blit(t1, t1.get_rect(center=(game_w // 2, self._WH // 2 - 40)))
+        # "GET ON THE FIELD" + abandon countdown bar, centered
+        font_huge = pygame.font.SysFont("monospace", 72, bold=True)
+        t1 = font_huge.render("GET ON THE FIELD", True, YELLOW)
+        cx = self._WW // 2
+        cy = bar_h + area_h // 2 - 40
+        surf.blit(t1, t1.get_rect(center=(cx, cy)))
 
         remaining = max(0.0, self._abandon_s - self._abandon_t)
         pct       = remaining / max(self._abandon_s, 0.001)
-        bar_w     = game_w * 2 // 3
-        bar_h     = 16
-        bx        = (game_w - bar_w) // 2
-        by        = self._WH // 2 + 20
-        pygame.draw.rect(surf, MID_GREY, (bx, by, bar_w, bar_h))
-        pygame.draw.rect(surf, RED, (bx, by, max(0, int(bar_w * pct)), bar_h))
-        pygame.draw.rect(surf, WHITE, (bx, by, bar_w, bar_h), 1)
-
-    def _draw_win_overlay(self, surf: pygame.Surface, game_w: int) -> None:
-        overlay = pygame.Surface((game_w, self._WH), pygame.SRCALPHA)
-        overlay.fill((0, 200, 80, 80))
-        surf.blit(overlay, (0, 0))
-        t = self._font_huge.render("YOU SURVIVED", True, WHITE)
-        surf.blit(t, t.get_rect(center=(game_w // 2, self._WH // 2)))
+        bar_w     = self._WW * 2 // 3
+        bar_h_px  = 20
+        bx        = (self._WW - bar_w) // 2
+        by        = bar_h + area_h // 2 + 30
+        pygame.draw.rect(surf, MID_GREY, (bx, by, bar_w, bar_h_px))
+        pygame.draw.rect(surf, RED, (bx, by, max(0, int(bar_w * pct)), bar_h_px))
+        pygame.draw.rect(surf, WHITE, (bx, by, bar_w, bar_h_px), 1)
 
     def _draw_confetti(self, surf: pygame.Surface) -> None:
         for p in self._particles:
@@ -526,41 +507,6 @@ class BodyKeepawayGame:
             tile  = pygame.Surface((s * 2, s * 2), pygame.SRCALPHA)
             tile.fill((*p.color, alpha))
             surf.blit(tile, (int(p.x) - s, int(p.y) - s))
-
-    def _draw_taunt(self, surf: pygame.Surface, game_w: int) -> None:
-        t = self._font_taunt.render(self._taunt, True, RED)
-        surf.blit(t, t.get_rect(center=(game_w // 2, self._WH // 2)))
-
-    def _draw_hud(self, surf: pygame.Surface) -> None:
-        g = self._grid
-        if g is None:
-            return
-        g.draw_hud_bg(surf)
-        x = g.hud_rect.x
-        y = 20
-
-        level_num = self._level_idx + 1
-        y = draw_hud_label(surf, self._font_big, "LEVEL",
-                           f"{level_num}/{len(self._all_levels)}", x, y)
-
-        if self._state in (_State.GRACE, _State.PLAYING, _State.NO_RUNNERS):
-            remaining = max(0.0, self._survive_s - self._elapsed)
-            vc = RED if remaining <= 5 else GREEN
-            y  = draw_hud_label(surf, self._font_big, "SURVIVE",
-                                f"{int(remaining)}s", x, y, value_color=vc)
-
-            if self._state == _State.NO_RUNNERS:
-                ab_remaining = max(0.0, self._abandon_s - self._abandon_t)
-                draw_hud_label(surf, self._font_sml, "ABANDON IN",
-                               f"{int(ab_remaining)}s", x, y, value_color=RED)
-
-        elif self._state == _State.WIN_FLASH:
-            t = self._font_big.render("LEVEL CLEAR!", True, GREEN)
-            surf.blit(t, (x + 8, y))
-
-        elif self._state == _State.WIN_FINAL:
-            t = self._font_big.render("YOU WIN!", True, GREEN)
-            surf.blit(t, (x + 8, y))
 
 
 def create(settings: dict) -> BodyKeepawayGame:

--- a/ShowControl/FundingCAPTCHA/games/bodycaptcha.py
+++ b/ShowControl/FundingCAPTCHA/games/bodycaptcha.py
@@ -1,4 +1,4 @@
-"""BodyCaptcha — silhouette CAPTCHA grid-matching game (ADR-0013)."""
+"""BodyCaptcha — silhouette CAPTCHA grid-matching game (ADR-0013, ADR-0019)."""
 from __future__ import annotations
 
 import json
@@ -16,7 +16,8 @@ log = logging.getLogger(__name__)
 from games.grid import (
     Grid,
     BLACK, WHITE, DK_GREY, MID_GREY, LT_GREY, GREEN, YELLOW, RED, CYAN, ORANGE,
-    HUD_W, hud_font, draw_hud_label, draw_progress_bar,
+    HOLD_RING_COLOR,
+    top_bar_height, draw_top_bar, draw_hold_ring, draw_center_text,
 )
 from body_grid import BodyGridActivator, BodyGridConfig, SlabConfig, CellActivations
 
@@ -28,7 +29,6 @@ _TAUNTS = _DIR / "taunts.json"
 HINT_COLOR   = (100, 180, 255)
 COVER_VALID  = (  0, 220,  80)
 COVER_EXTRA  = (220,  50,  50)
-HOLD_COLOR   = (  0, 255, 130)
 
 _WIN_FLASH_S = 0.5
 _BLOWUP_S    = 2.8
@@ -175,9 +175,6 @@ class BodyCaptchaGame:
         WW, WH           = pygame.display.get_surface().get_size()
         self._WW         = WW
         self._WH         = WH
-        self._font_big   = hud_font(22)
-        self._font_sml   = hud_font(16)
-        self._font_taunt = pygame.font.SysFont("monospace", 22, bold=True)
 
         # Live state (set by _load_level)
         self._level:       dict             = {}
@@ -202,9 +199,9 @@ class BodyCaptchaGame:
     def _load_level(self, level: dict) -> None:
         self._level      = level
         cols, rows       = level.get("grid", [4, 4])
-        game_w           = self._WW - HUD_W
         self._grid       = Grid(self._WW, self._WH, cols, rows)
-        self._bg_img     = _load_bg(level.get("image"), game_w, self._WH)
+        bounds           = self._grid.bounds_rect
+        self._bg_img     = _load_bg(level.get("image"), bounds.width, bounds.height)
         self._activator  = _make_activator(level, self._settings)
         self._valid_set  = {tuple(c) for c in level.get("valid_cells", [])}
         self._elapsed    = 0.0
@@ -328,27 +325,30 @@ class BodyCaptchaGame:
             return
 
         surf.fill(BLACK)
-        game_w = self._WW - HUD_W
-
-        # Background image or dark fill
-        if self._bg_img:
-            surf.blit(self._bg_img, (0, 0))
-        else:
-            pygame.draw.rect(surf, DK_GREY, (0, 0, game_w, self._WH))
+        bounds  = g.bounds_rect
+        bar_h   = g.top_reserve
+        prompt  = self._level.get("prompt", "")
 
         if self._state == _State.BLOWUP:
             self._draw_confetti(surf)
-            self._draw_hud(surf)
+            draw_center_text(surf, self._taunt, RED,
+                             self._WW, bar_h, self._WH, max_font=120)
+            draw_top_bar(surf, self._WW, bar_h, prompt, None)
             return
 
-        # Silhouette overlay (faint — helps player see their body in context)
+        # Photo, clipped to grid bounds
+        if self._bg_img is not None:
+            surf.blit(self._bg_img, bounds.topleft)
+
+        # Silhouette overlay (faint), scaled to grid bounds
         if self._foreground is not None:
             slab_color  = tuple(self._settings.get("slab_styles", {})
                                 .get("0", {}).get("color", [0, 220, 100]))
             sil = _foreground_surf(self._foreground, self._slabs_cfg,
-                                   self._roi, slab_color, game_w, self._WH)
+                                   self._roi, slab_color,
+                                   bounds.width, bounds.height)
             sil.set_alpha(60)
-            surf.blit(sil, (0, 0))
+            surf.blit(sil, bounds.topleft)
 
         # Cell overlays
         covered     = set(self._activations.keys())
@@ -370,7 +370,7 @@ class BodyCaptchaGame:
                     else:
                         continue
                 elif is_covered and is_valid:
-                    color, alpha = (HOLD_COLOR if hold_active else COVER_VALID), 190
+                    color, alpha = (HOLD_RING_COLOR if hold_active else COVER_VALID), 190
                 elif is_covered and not is_valid:
                     color, alpha = COVER_EXTRA, 160
                 elif is_valid and not is_covered:
@@ -387,7 +387,18 @@ class BodyCaptchaGame:
             for c in range(g.cols):
                 pygame.draw.rect(surf, MID_GREY, g.cell_rect(c, r), 1)
 
-        self._draw_hud(surf)
+        # Hold-progress ring on grid perimeter
+        if self._state == _State.PLAYING and self._hold_elapsed > 0:
+            draw_hold_ring(surf, bounds, self._hold_elapsed / max(self._hold_s, 0.001))
+
+        # Win flash centered text
+        if self._state == _State.WIN_FLASH:
+            draw_center_text(surf, "LEVEL CLEAR!", GREEN,
+                             self._WW, bar_h, self._WH, max_font=140)
+
+        # Top bar (prompt + timer)
+        remaining = max(0.0, self._timer_s - self._elapsed)
+        draw_top_bar(surf, self._WW, bar_h, prompt, remaining)
 
     def _draw_confetti(self, surf: pygame.Surface) -> None:
         for p in self._particles:
@@ -396,70 +407,6 @@ class BodyCaptchaGame:
             tile  = pygame.Surface((s * 2, s * 2), pygame.SRCALPHA)
             tile.fill((*p.color, alpha))
             surf.blit(tile, (int(p.x) - s, int(p.y) - s))
-
-    def _draw_hud(self, surf: pygame.Surface) -> None:
-        g = self._grid
-        if g is None:
-            return
-        g.draw_hud_bg(surf)
-        x = g.hud_rect.x
-        w = g.hud_rect.width
-        y = 20
-
-        if self._state == _State.BLOWUP:
-            y = 80
-            for line in _wrap(self._taunt, 18):
-                t = self._font_taunt.render(line, True, RED)
-                surf.blit(t, (x + 8, y))
-                y += t.get_height() + 4
-            return
-
-        if self._state == _State.WIN_FLASH:
-            t = self._font_big.render("LEVEL CLEAR!", True, GREEN)
-            surf.blit(t, (x + 8, y))
-            y += t.get_height() + 14
-
-        remaining = max(0.0, self._timer_s - self._elapsed)
-        vc = RED if remaining <= 10 else GREEN
-        y  = draw_hud_label(surf, self._font_big, "TIME", f"{int(remaining)}s",
-                            x, y, value_color=vc)
-        draw_progress_bar(surf, x + 8, y, w - 24, 12, remaining / max(self._timer_s, 1), color=vc)
-        y += 22
-
-        diff = self._level.get("difficulty", 1)
-        y    = draw_hud_label(surf, self._font_big, "DIFFICULTY", f"{diff}/5", x, y)
-
-        if self._hold_elapsed > 0 and self._state == _State.PLAYING:
-            hold_pct = min(1.0, self._hold_elapsed / self._hold_s)
-            draw_progress_bar(surf, x + 8, y, w - 24, 16, hold_pct, color=HOLD_COLOR)
-            t = self._font_sml.render("HOLD", True, HOLD_COLOR)
-            surf.blit(t, (x + 8, y + 2))
-            y += 26
-
-        # Prompt at bottom of HUD
-        prompt = self._level.get("prompt", "")
-        if prompt:
-            lh    = self._font_sml.get_height() + 2
-            lines = _wrap(prompt, 18)
-            py    = g.hud_rect.bottom - len(lines) * lh - 20
-            for line in lines:
-                t = self._font_sml.render(line, True, WHITE)
-                surf.blit(t, (x + 8, py))
-                py += lh
-
-
-def _wrap(text: str, width: int) -> list[str]:
-    words, lines, cur = text.split(), [], ""
-    for word in words:
-        candidate = (cur + " " + word).strip()
-        if len(candidate) > width and cur:
-            lines.append(cur)
-            cur = word
-        else:
-            cur = candidate
-    if cur:
-        lines.append(cur)
-    return lines
 
 
 def create(settings: dict) -> BodyCaptchaGame:

--- a/ShowControl/FundingCAPTCHA/games/grid.py
+++ b/ShowControl/FundingCAPTCHA/games/grid.py
@@ -1,5 +1,6 @@
-"""Shared pygame grid, tap detection, and HUD helpers for FundingCAPTCHA games."""
+"""Shared pygame grid and Game-UI shell helpers for FundingCAPTCHA games (ADR-0019)."""
 from __future__ import annotations
+import math
 import pygame
 
 BLACK    = (  0,   0,   0)
@@ -22,30 +23,52 @@ HIT_COLOR       = GREEN
 MISS_COLOR      = RED
 HIGHLIGHT_COLOR = CYAN
 
-HUD_W    = 220
 CELL_PAD = 4
+
+# Shell layout (ADR-0019)
+TOP_BAR_FRACTION = 0.12        # 12% of screen height
+PROMPT_FONT_CAP  = 72          # max prompt font size — short prompts don't become billboards
+TIMER_FONT_SIZE  = 32
+TIMER_PAD        = 16          # right-edge padding for timer text
+HOLD_RING_COLOR  = (0, 255, 130)
+HOLD_RING_THICK  = 12          # perimeter ring thickness in pixels
+HOLD_RING_INSET  = 2           # inset from grid bounds
+
+
+def top_bar_height(screen_h: int) -> int:
+    return int(screen_h * TOP_BAR_FRACTION)
 
 
 class Grid:
-    """Letterboxed cell grid occupying the left portion of the screen."""
+    """Letterboxed square-cell grid below the top bar (ADR-0019)."""
 
     def __init__(self, screen_w: int, screen_h: int,
-                 cols: int, rows: int, hud_width: int = HUD_W) -> None:
-        self.cols     = cols
-        self.rows     = rows
-        self.hud_rect = pygame.Rect(screen_w - hud_width, 0, hud_width, screen_h)
-
-        game_w = screen_w - hud_width
-        cell   = min(game_w // cols, screen_h // rows)
+                 cols: int, rows: int, top_reserve: int | None = None) -> None:
+        self.cols = cols
+        self.rows = rows
+        top = top_bar_height(screen_h) if top_reserve is None else top_reserve
+        area_h = screen_h - top
+        cell = min(screen_w // cols, area_h // rows)
         gw, gh = cell * cols, cell * rows
-        self._gx   = (game_w - gw) // 2
-        self._gy   = (screen_h - gh) // 2
+        self._gx = (screen_w - gw) // 2
+        self._gy = top + (area_h - gh) // 2
         self._cell = cell
+        self._top_reserve = top
         self._flashes: dict[tuple[int, int], tuple] = {}
 
     @property
     def cell_size(self) -> int:
         return self._cell
+
+    @property
+    def top_reserve(self) -> int:
+        return self._top_reserve
+
+    @property
+    def bounds_rect(self) -> pygame.Rect:
+        return pygame.Rect(self._gx, self._gy,
+                           self._cell * self.cols,
+                           self._cell * self.rows)
 
     def cell_rect(self, col: int, row: int) -> pygame.Rect:
         return pygame.Rect(
@@ -81,11 +104,6 @@ class Grid:
         for k in dead:
             del self._flashes[k]
 
-    def draw_hud_bg(self, surf: pygame.Surface) -> None:
-        pygame.draw.rect(surf, (18, 18, 18), self.hud_rect)
-        pygame.draw.line(surf, MID_GREY,
-                         self.hud_rect.topleft, self.hud_rect.bottomleft, 1)
-
     def blit_cell(self, surf: pygame.Surface,
                   img: pygame.Surface, col: int, row: int) -> None:
         r = self.inner_rect(col, row)
@@ -96,20 +114,113 @@ def hud_font(size: int = 20) -> pygame.font.Font:
     return pygame.font.SysFont("monospace", size, bold=True)
 
 
-def draw_hud_label(surf: pygame.Surface, font: pygame.font.Font,
-                   label: str, value: str, x: int, y: int,
-                   value_color: tuple = WHITE) -> int:
-    """Draw label + value. Returns y below the row."""
-    lbl = font.render(label, True, LT_GREY)
-    val = font.render(value, True, value_color)
-    surf.blit(lbl, (x + 8, y))
-    surf.blit(val, (x + 8, y + lbl.get_height() + 2))
-    return y + lbl.get_height() + val.get_height() + 14
+# ── Shell rendering (ADR-0019) ────────────────────────────────────────────────
 
 
-def draw_progress_bar(surf: pygame.Surface,
-                      x: int, y: int, w: int, h: int,
-                      pct: float, color: tuple = GREEN) -> None:
-    pygame.draw.rect(surf, MID_GREY, (x, y, w, h))
-    pygame.draw.rect(surf, color,    (x, y, max(0, int(w * pct)), h))
-    pygame.draw.rect(surf, WHITE,    (x, y, w, h), 1)
+def _fit_prompt_font(text: str, max_w: int, max_h: int) -> pygame.font.Font:
+    """Largest monospace-bold font that fits text on one line within max_w × max_h."""
+    if not text:
+        return hud_font(min(PROMPT_FONT_CAP, max(8, max_h)))
+    lo, hi = 8, min(PROMPT_FONT_CAP, max(8, max_h))
+    best = lo
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        f   = hud_font(mid)
+        w, h = f.size(text)
+        if w <= max_w and h <= max_h:
+            best = mid
+            lo = mid + 1
+        else:
+            hi = mid - 1
+    return hud_font(best)
+
+
+def draw_top_bar(surf: pygame.Surface,
+                 screen_w: int, bar_h: int,
+                 prompt: str,
+                 time_remaining: float | None,
+                 *,
+                 timer_warn_s: float = 10.0) -> None:
+    """Shared shell top bar: centered prompt + top-right timer (ADR-0019)."""
+    pygame.draw.rect(surf, BLACK, (0, 0, screen_w, bar_h))
+
+    timer_reserve = 0
+    if time_remaining is not None:
+        font_t = hud_font(TIMER_FONT_SIZE)
+        color  = RED if time_remaining <= timer_warn_s else GREEN
+        label  = f"{int(max(0.0, time_remaining))}s"
+        t_surf = font_t.render(label, True, color)
+        tx     = screen_w - t_surf.get_width() - TIMER_PAD
+        ty     = (bar_h - t_surf.get_height()) // 2
+        surf.blit(t_surf, (tx, ty))
+        timer_reserve = t_surf.get_width() + TIMER_PAD * 2
+
+    if prompt:
+        avail_w = max(40, screen_w - 2 * timer_reserve)
+        avail_h = int(bar_h * 0.7)
+        font_p  = _fit_prompt_font(prompt, avail_w, avail_h)
+        p_surf  = font_p.render(prompt, True, WHITE)
+        px      = (screen_w - p_surf.get_width()) // 2
+        py      = (bar_h - p_surf.get_height()) // 2
+        surf.blit(p_surf, (px, py))
+
+
+def draw_hold_ring(surf: pygame.Surface, bounds: pygame.Rect, pct: float) -> None:
+    """Clockwise-filling perimeter ring on the grid bounds, no track (ADR-0019)."""
+    pct = max(0.0, min(1.0, pct))
+    if pct <= 0.0:
+        return
+    rect = bounds.inflate(-HOLD_RING_INSET * 2, -HOLD_RING_INSET * 2)
+    # pygame.draw.arc draws counter-clockwise from start_angle to stop_angle.
+    # We want a clockwise-filling arc starting at 12 o'clock (top).
+    end_angle   = math.pi / 2.0
+    start_angle = end_angle - 2.0 * math.pi * pct
+    pygame.draw.arc(surf, HOLD_RING_COLOR, rect, start_angle, end_angle, HOLD_RING_THICK)
+
+
+def _wrap_to_width(text: str, font: pygame.font.Font, max_w: int) -> list[str]:
+    words, lines, cur = text.split(), [], ""
+    for word in words:
+        candidate = (cur + " " + word).strip()
+        if font.size(candidate)[0] <= max_w or not cur:
+            cur = candidate
+        else:
+            lines.append(cur)
+            cur = word
+    if cur:
+        lines.append(cur)
+    return lines
+
+
+def draw_center_text(surf: pygame.Surface, text: str, color: tuple,
+                     screen_w: int, top_y: int, screen_h: int,
+                     *, max_font: int = 96, padding: float = 0.08) -> None:
+    """Big multi-line centered text inside the grid area below the top bar (ADR-0019)."""
+    if not text:
+        return
+    area_h  = screen_h - top_y
+    avail_w = int(screen_w * (1.0 - padding * 2))
+    avail_h = int(area_h * (1.0 - padding * 2))
+
+    lo, hi = 16, max_font
+    best_font  = hud_font(lo)
+    best_lines = [text]
+    while lo <= hi:
+        mid   = (lo + hi) // 2
+        f     = hud_font(mid)
+        lines = _wrap_to_width(text, f, avail_w)
+        h     = len(lines) * f.get_height()
+        if h <= avail_h and all(f.size(ln)[0] <= avail_w for ln in lines):
+            best_font, best_lines = f, lines
+            lo = mid + 1
+        else:
+            hi = mid - 1
+
+    line_h  = best_font.get_height()
+    total_h = line_h * len(best_lines)
+    y       = top_y + (area_h - total_h) // 2
+    for line in best_lines:
+        s  = best_font.render(line, True, color)
+        sx = (screen_w - s.get_width()) // 2
+        surf.blit(s, (sx, y))
+        y += line_h

--- a/docs/adr/0019-fundingcaptcha-game-ui-shell.md
+++ b/docs/adr/0019-fundingcaptcha-game-ui-shell.md
@@ -1,0 +1,71 @@
+# FundingCAPTCHA Games share a single UI shell — billboard prompt + maximal grid
+
+## Context
+
+The original BodyCaptcha layout (`games/bodycaptcha.py`, `games/grid.py`) carried over the early prototype's right-hand HUD column: a 220px vertical strip holding TIME, DIFFICULTY, HOLD bar, and prompt text. The Grid letterboxed inside the remaining left area.
+
+Two problems showed up on the FundingCAPTCHA kiosk (4:3 short-throw projection):
+
+- **The prompt was unreadable from Player distance.** Wrapped 16pt monospace inside a 220px column reads as filler text, not as instruction. Players didn't know what they were being asked to do.
+- **The grid was cramped.** The HUD strip burned ~21% of screen width on data Players don't need to see (DIFFICULTY) or didn't notice (the HOLD bar tucked off to the side).
+
+BodyCaptcha is the first FundingCAPTCHA Game with this shell, but `body_keepaway` already uses the same `Grid` + `HUD_W=220` primitives, and future Games are expected. The visual contract should be consistent across Games — Players are cycling through Arcs and the kiosk should feel like one machine, not four.
+
+## Decision
+
+All FundingCAPTCHA Games render against a single shared UI shell:
+
+```
+┌──────────────────────────────────────────────────────────┐
+│   Select all squares containing a smile           23s   │   ← Top bar (12% of WH)
+├──────────────────────────────────────────────────────────┤
+│                                                          │
+│              [ photo, clipped to grid bounds ]           │
+│              [ grid cells + silhouette overlay ]         │
+│              [ optional hold-ring on grid perimeter ]    │
+│                                                          │
+│                                                          │
+└──────────────────────────────────────────────────────────┘
+```
+
+**Top bar** (top 12% of screen, full width, solid black):
+- Prompt text, centered horizontally and vertically. Auto-shrink-to-fit on one line, with a sensible upper font cap so short prompts don't become billboards.
+- Level timer in the top-right corner, fairly small, GREEN when >10s remaining, RED when ≤10s. Number only (e.g. `23s`) — no bar, no ring.
+- No separator line between bar and grid area — black-on-black reads as one composition with the photo edges as the only visible boundary.
+- Prompt is **optional**: when absent (e.g. `keepaway_body` today), the bar still renders for layout consistency but only shows the timer.
+
+**Grid area** (remaining ~88% of WH, full width):
+- Photo (level background image) is clipped to grid bounds — no bleed past grid edges. The photo and the grid are one visual unit, not two stacked layers.
+- Silhouette overlay (faint, alpha ~60) renders over the photo so Players can see how their body maps to cells.
+- Cell-activation overlays unchanged: HINT_COLOR for valid-and-uncovered, COVER_VALID for valid-and-covered, COVER_EXTRA for invalid-and-covered, HOLD_COLOR when hold is active.
+
+**Hold-ring overlay** (opt-in per Game):
+- When all `valid_cells` are covered and no extras, a thick (~8–12px) clockwise-filling arc renders along the grid's outer perimeter in HOLD_COLOR.
+- No background track — empty state = clean grid; full ring = win imminent.
+- Only Games with a hold mechanic enable it. `keepaway_body` does not.
+
+**Center overlays** (per-game moments):
+- WIN_FLASH "LEVEL CLEAR!" renders as large centered text over the grid (cells already flashing green underneath).
+- Blow-Up taunts render as large multi-line centered text over the confetti animation.
+- Games may add their own per-Arc center overlays as needed.
+
+The 220px HUD column (`HUD_W` in `games/grid.py`) is removed. `Grid` letterboxing logic now letterboxes inside the full-width-below-top-bar area.
+
+## Alternatives considered
+
+**Keep the HUD column, just enlarge the prompt.** Rejected. The HUD column cap was the bottleneck — at 220px wide, even with a bigger font the prompt has to wrap to 2–3 lines and competes with HUD widgets above it. Burning ~21% of screen width on infrequently-read data (DIFFICULTY) is the larger problem; enlarging the prompt inside the same cage doesn't fix it.
+
+**Auto-grow top bar.** Bar height = whatever the longest prompt needs at a fixed point size; grid takes the rest. Rejected. Layout would shift level-to-level — the photo box stretches and shrinks across Levels, which is visually jarring during an Arc. A fixed 12% bar gives the grid a stable size.
+
+**Multi-line wrapped prompt in a fixed bar.** Rejected for the same reason — short prompts then look like billboards while long prompts squeeze the grid further. Auto-shrink-to-fit-one-line is the simpler invariant: prompt always one line, font scales to fit.
+
+**Hold timer in the top bar instead of overlaid on grid.** Rejected. The hold is a 1-second "doing it right" moment — it needs to be in the Player's foveal vision, which is on the grid where their body is. A widget in the top bar is peripheral when it most needs to be central.
+
+## Consequences
+
+- `HUD_W` is removed from `games/grid.py`. `Grid.__init__` no longer takes a `hud_width` parameter; `Grid.hud_rect`, `Grid.draw_hud_bg()`, and the HUD label/progress-bar helpers (`draw_hud_label`, `draw_progress_bar`) become unused and should be deleted.
+- `games/bodycaptcha.py` `_draw_hud()` is replaced by shell rendering (top bar + hold ring + center overlays). The "DIFFICULTY" indicator is dropped from the screen — designers know it from the Level file, Players don't need it.
+- `games/body_keepaway.py` migrates to the same shell. Its Levels gain an optional `prompt` field if designers want one; otherwise the bar shows only the timer.
+- Shell rendering is shared across Games. Implementation choice (helper functions in `grid.py` vs. a new `games/shell.py` module vs. a `GameShell` class) is left to the implementer — the contract above is what matters.
+- Future Games inherit this shell by default. Deviating (e.g. a Game without a grid at all) is allowed but should be a deliberate design choice, not an accident.
+- The "select all squares" CAPTCHA mimicry reads more strongly: prompt billboard at top + image grid below is the exact reCAPTCHA shape, which is the joke FundingCAPTCHA is making.


### PR DESCRIPTION
## Summary

- Kills the 220px HUD column. Top 12% becomes a black bar holding the centered prompt (auto-shrunk to one line, font cap so short prompts don''t billboard) and the level timer in the top-right (GREEN→RED at the warn threshold).
- Grid + photo own the rest of the screen. Photo is clipped to grid bounds so the two read as one visual unit (no bleed past grid edges). Silhouette overlay scaled to the same bounds.
- BodyCaptcha gains a clockwise-filling perimeter hold ring on the grid edge — the "you''re doing it right" affordance lives where the player''s eye already is, not in a side widget. No background track.
- BodyKeepaway migrates to the same shell. Prompt is optional (Keepaway has none today). Hold ring is opt-in and disabled here.
- WIN_FLASH ("LEVEL CLEAR!") and Blow-Up taunts render as large multi-line center overlays inside the grid area.
- New ADR-0019 records the shell as the shared contract for all FundingCAPTCHA Games and the decisions behind it.

## Test plan

- [x] Headless smoke tests pass for `grid.py` shell helpers and both Games'' states (PLAYING / WIN_FLASH / WIN_FINAL / BLOWUP / GRACE / NO_RUNNERS)
- [ ] Run `app.py --test-input` on the kiosk and confirm:
  - [ ] Prompt is clearly readable from player distance
  - [ ] Timer top-right is readable and turns red ≤10s remaining
  - [ ] Hold ring fills clockwise over ~1s when correct cells are activated
  - [ ] Photo stays within grid bounds (no bleed)
  - [ ] LEVEL CLEAR! and Blow-Up taunt render centered over the grid
- [ ] Repeat with `app.py --camera` end-to-end