### PR TITLE
fix(captcha): git lfs pull in install + detect LFS pointers at load

### DIFF
--- a/ShowControl/FundingCAPTCHA/deploy/install.sh
+++ b/ShowControl/FundingCAPTCHA/deploy/install.sh
@@ -23,6 +23,12 @@ echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="2bc5", ATTR{idProduct}=="0807", MODE="0
 udevadm control --reload-rules
 udevadm trigger
 
+# ── Git LFS ───────────────────────────────────────────────────────────────────
+echo "→ Installing git-lfs and pulling LFS assets (background images)..."
+apt-get install -y git-lfs 2>/dev/null || true
+git -C "$REPO_ROOT" lfs install
+git -C "$REPO_ROOT" lfs pull
+
 # ── Python dependencies ────────────────────────────────────────────────────────
 echo "→ Installing Python dependencies..."
 apt-get install -y python3-numpy python3-scipy 2>/dev/null || true

--- a/ShowControl/FundingCAPTCHA/games/bodycaptcha.py
+++ b/ShowControl/FundingCAPTCHA/games/bodycaptcha.py
@@ -109,6 +109,11 @@ def _load_taunts() -> list[str]:
 
 def _img_load(path: Path) -> pygame.Surface:
     """Load image via pygame, falling back to Pillow for unsupported formats (e.g. JPEG on Pi)."""
+    with open(path, "rb") as f:
+        if f.read(20).startswith(b"version https://git-"):
+            raise RuntimeError(
+                f"Git LFS pointer at {path} — run `git lfs pull` in the repo root"
+            )
     try:
         return pygame.image.load(str(path)).convert()
     except Exception:


### PR DESCRIPTION
## Problem
Background images are JPEGs tracked in Git LFS. If `git lfs pull` was never run on the Pi the files are pointer stubs — `_img_load` silently shows a black rect.

## Changes
- `deploy/install.sh`: add `git lfs install` + `git lfs pull` so assets are present after setup
- `bodycaptcha.py/_img_load`: detect LFS pointer bytes at load time and raise with a clear message rather than falling through to a black surface

## On-site fix (if already deployed)
```bash
sudo apt install git-lfs
git -C /path/to/repo lfs install
git -C /path/to/repo lfs pull
sudo systemctl restart captcha
```