### PR TITLE
fix(flowerbeds): update camera config for house-top angled mount

### DIFF
--- a/ShowControl/FlowerBeds/settings.json
+++ b/ShowControl/FlowerBeds/settings.json
@@ -828,16 +828,17 @@
   "activity_max_blobs": 10,
   "cameras": [
     {
+      "_note": "Camera mounted on top of house (~290cm Z), ~244cm past module row 2 (Y≈484). Facing toward audience entrance (yaw=180). 30° down from horizontal (pitch=-30). Calibrate pos_cm and roll on-site with --visualizer.",
       "name": "Camera",
       "pos_cm": [
         300,
-        120.0,
-        275.0
+        484,
+        290
       ],
       "rotation": {
-        "pitch": -90.0,
-        "yaw": 0,
-        "roll": 180.0
+        "pitch": -30,
+        "yaw": 180,
+        "roll": 0
       },
       "width": 640,
       "height": 400,


### PR DESCRIPTION
## Change
Camera moved from overhead (pitch=-90) to top of TreeHouse structure facing audience.

| param | old | new |
|---|---|---|
| pos_cm | [300, 120, 275] | [300, 484, 290] |
| pitch | -90 | -30 |
| yaw | 0 | 180 |
| roll | 180 | 0 |

Camera is ~9.5 ft (290 cm) high, ~8 ft (244 cm) past module row 2, facing toward audience entering through the beds.

## On-site calibration required
After mounting:
1. `python3 main.py --visualizer`
2. Walk through beds, confirm blobs track correct ground positions
3. Tune `pos_cm` x/y, `roll`, and `depth_delta_mm` as needed