### PR TITLE
Collapse three silhouette renderers into one module

### DIFF
--- a/ShowControl/FundingCAPTCHA/app.py
+++ b/ShowControl/FundingCAPTCHA/app.py
@@ -44,7 +44,7 @@ sys.path.insert(0, str(DIR.parent.parent))  # IIVision
 sys.path.insert(0, str(DIR.parent))         # OSCFabric
 sys.path.insert(0, str(DIR))                # body_grid, games
 
-from silhouette import build_cam_transform, apply_cam_transform
+from silhouette import build_cam_transform, apply_cam_transform, render_silhouette
 
 # ── Optional imports ──────────────────────────────────────────────────────────
 try:
@@ -280,23 +280,6 @@ def _camera_inner(camera: Any, settings: dict,
 
 
 # ── Silhouette rendering ──────────────────────────────────────────────────────
-
-def _silhouette_surf(foreground: np.ndarray, slabs_cfg: list[dict],
-                     roi: dict, color: tuple,
-                     display_w: int, display_h: int) -> pygame.Surface:
-    """Render foreground depth frame as a colored mask, scaled to display size."""
-    cropped = foreground[roi["y"]:roi["y"] + roi["h"], roi["x"]:roi["x"] + roi["w"]]
-    H, W    = cropped.shape
-    mask    = np.zeros((H, W), dtype=bool)
-    for s in slabs_cfg:
-        mask |= (cropped >= s["near_mm"]) & (cropped < s["far_mm"])
-    rgb = np.zeros((W, H, 3), dtype=np.uint8)
-    rgb[mask.T, 0] = color[0]
-    rgb[mask.T, 1] = color[1]
-    rgb[mask.T, 2] = color[2]
-    surf = pygame.surfarray.make_surface(rgb)
-    return pygame.transform.scale(surf, (display_w, display_h))
-
 
 # ── Test input handler ────────────────────────────────────────────────────────
 
@@ -751,8 +734,8 @@ def main() -> None:
                 # scaled surface instead of re-masking + re-scaling to full HD.
                 if current_foreground is not None:
                     if fg_new or sil_cache is None:
-                        sil_cache = _silhouette_surf(current_foreground, slabs_cfg,
-                                                     roi, slab_color, game_w, WH)
+                        sil_cache = render_silhouette(current_foreground, slabs_cfg,
+                                                      roi, slab_color, game_w, WH)
                         sil_cache.set_alpha(int(sil_opacity * 255))
                     screen.blit(sil_cache, (0, 0))
 

--- a/ShowControl/FundingCAPTCHA/games/body_keepaway.py
+++ b/ShowControl/FundingCAPTCHA/games/body_keepaway.py
@@ -19,6 +19,7 @@ from games.grid import (
     hud_font, top_bar_height, draw_top_bar, draw_center_text,
 )
 from body_grid import BodyGridActivator, BodyGridConfig, SlabConfig, CellActivations
+from silhouette import render_silhouette
 
 _DIR    = Path(__file__).parent.parent
 _LEVELS = _DIR / "keepaway-body-levels.json"
@@ -166,21 +167,6 @@ def _spawn_defenders(defender_cfgs: list[dict], cols: int, rows: int) -> list[_D
         _Defender(positions[i][0], positions[i][1], cfg["speed"], cols, rows)
         for i, cfg in enumerate(defender_cfgs)
     ]
-
-
-def _foreground_surf(foreground: np.ndarray, slabs_cfg: list[dict],
-                     roi: dict, color: tuple, w: int, h: int) -> pygame.Surface:
-    cropped = foreground[roi["y"]:roi["y"] + roi["h"], roi["x"]:roi["x"] + roi["w"]]
-    H, W    = cropped.shape
-    mask    = np.zeros((H, W), dtype=bool)
-    for s in slabs_cfg:
-        mask |= (cropped >= s["near_mm"]) & (cropped < s["far_mm"])
-    rgb        = np.zeros((W, H, 3), dtype=np.uint8)
-    rgb[mask.T, 0] = color[0]
-    rgb[mask.T, 1] = color[1]
-    rgb[mask.T, 2] = color[2]
-    surf = pygame.surfarray.make_surface(rgb)
-    return pygame.transform.scale(surf, (w, h))
 
 
 def _draw_stick_figure(surf: pygame.Surface, cx: int, cy: int,
@@ -423,9 +409,9 @@ class BodyKeepawayGame:
         if self._foreground is not None:
             slab_color = tuple(self._settings.get("slab_styles", {})
                                .get("0", {}).get("color", [0, 220, 100]))
-            sil = _foreground_surf(self._foreground, self._slabs_cfg,
-                                   self._roi, slab_color,
-                                   bounds.width, bounds.height)
+            sil = render_silhouette(self._foreground, self._slabs_cfg,
+                                    self._roi, slab_color,
+                                    bounds.width, bounds.height)
             sil.set_alpha(60)
             surf.blit(sil, bounds.topleft)
 

--- a/ShowControl/FundingCAPTCHA/games/bodycaptcha.py
+++ b/ShowControl/FundingCAPTCHA/games/bodycaptcha.py
@@ -20,6 +20,7 @@ from games.grid import (
     top_bar_height, draw_top_bar, draw_hold_ring, draw_center_text,
 )
 from body_grid import BodyGridActivator, BodyGridConfig, SlabConfig, CellActivations
+from silhouette import render_silhouette
 
 _DIR    = Path(__file__).parent.parent
 _IMAGES = _DIR / "images"
@@ -155,21 +156,6 @@ def _make_activator(level: dict, settings: dict) -> BodyGridActivator:
         cols=cols, rows=rows, camera_roi=roi,
         slabs=slabs, cell_activation_threshold=threshold,
     ))
-
-
-def _foreground_surf(foreground: np.ndarray, slabs_cfg: list[dict],
-                     roi: dict, color: tuple, w: int, h: int) -> pygame.Surface:
-    cropped = foreground[roi["y"]:roi["y"] + roi["h"], roi["x"]:roi["x"] + roi["w"]]
-    H, W    = cropped.shape
-    mask    = np.zeros((H, W), dtype=bool)
-    for s in slabs_cfg:
-        mask |= (cropped >= s["near_mm"]) & (cropped < s["far_mm"])
-    rgb        = np.zeros((W, H, 3), dtype=np.uint8)
-    rgb[mask.T, 0] = color[0]
-    rgb[mask.T, 1] = color[1]
-    rgb[mask.T, 2] = color[2]
-    surf = pygame.surfarray.make_surface(rgb)
-    return pygame.transform.scale(surf, (w, h))
 
 
 class BodyCaptchaGame:
@@ -378,9 +364,9 @@ class BodyCaptchaGame:
         if self._foreground is not None:
             slab_color  = tuple(self._settings.get("slab_styles", {})
                                 .get("0", {}).get("color", [0, 220, 100]))
-            sil = _foreground_surf(self._foreground, self._slabs_cfg,
-                                   self._roi, slab_color,
-                                   bounds.width, bounds.height)
+            sil = render_silhouette(self._foreground, self._slabs_cfg,
+                                    self._roi, slab_color,
+                                    bounds.width, bounds.height)
             sil.set_alpha(60)
             surf.blit(sil, bounds.topleft)
 

--- a/ShowControl/FundingCAPTCHA/silhouette.py
+++ b/ShowControl/FundingCAPTCHA/silhouette.py
@@ -1,14 +1,40 @@
-"""Camera-space silhouette correction for FundingCAPTCHA.
+"""Camera-space silhouette correction and rendering for FundingCAPTCHA.
 
-Two functions cover the full pipeline:
+Camera-space correction:
   build_cam_transform(settings) → Transform | None
   apply_cam_transform(fg, intrinsics, transform) → np.ndarray
+
+Display rendering:
+  render_silhouette(fg, slabs_cfg, roi, color, w, h) → pygame.Surface
 
 Grow to a class if state or additional config is needed.
 """
 from __future__ import annotations
 
 import numpy as np
+import pygame
+
+
+def render_silhouette(foreground: np.ndarray, slabs_cfg: list[dict],
+                      roi: dict, color: tuple, w: int, h: int) -> pygame.Surface:
+    """Render a foreground depth frame as a colored Play-Zone silhouette.
+
+    Crops to the camera ROI, masks pixels inside any Depth Slab
+    [near_mm, far_mm), paints them `color`, and scales to (w, h).
+    Single source of truth for the depth→silhouette mapping shared by the
+    attract overlay (app.py) and the in-game backdrops (games/).
+    """
+    cropped = foreground[roi["y"]:roi["y"] + roi["h"], roi["x"]:roi["x"] + roi["w"]]
+    H, W    = cropped.shape
+    mask    = np.zeros((H, W), dtype=bool)
+    for s in slabs_cfg:
+        mask |= (cropped >= s["near_mm"]) & (cropped < s["far_mm"])
+    rgb = np.zeros((W, H, 3), dtype=np.uint8)
+    rgb[mask.T, 0] = color[0]
+    rgb[mask.T, 1] = color[1]
+    rgb[mask.T, 2] = color[2]
+    surf = pygame.surfarray.make_surface(rgb)
+    return pygame.transform.scale(surf, (w, h))
 
 
 def build_cam_transform(settings: dict):

--- a/ShowControl/FundingCAPTCHA/test_silhouette.py
+++ b/ShowControl/FundingCAPTCHA/test_silhouette.py
@@ -1,0 +1,66 @@
+"""Tests for the shared silhouette renderer (depth → colored Play-Zone mask)."""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")  # headless: no real display
+
+import numpy as np
+import pygame
+
+from silhouette import render_silhouette
+
+
+_FULL_ROI = {"x": 0, "y": 0, "w": 4, "h": 4}
+_SLAB = [{"near_mm": 800, "far_mm": 2500, "slab_id": 0}]
+_COLOR = (10, 220, 80)
+
+
+def _identity_surf(fg: np.ndarray, slabs=_SLAB, roi=None, color=_COLOR):
+    """Render at 1:1 (w,h == roi w,h) so surface pixels map to fg pixels."""
+    roi = roi or _FULL_ROI
+    return render_silhouette(fg, slabs, roi, color, roi["w"], roi["h"])
+
+
+def test_in_slab_pixel_is_colored():
+    fg = np.zeros((4, 4), dtype=np.uint16)
+    fg[1, 2] = 1500  # inside [800, 2500)
+    surf = _identity_surf(fg)
+    # fg[row=1, col=2] → surface pixel (x=2, y=1)
+    assert surf.get_at((2, 1))[:3] == _COLOR
+
+
+def test_out_of_slab_pixels_are_black():
+    fg = np.zeros((4, 4), dtype=np.uint16)
+    fg[1, 2] = 1500
+    surf = _identity_surf(fg)
+    assert surf.get_at((0, 0))[:3] == (0, 0, 0)  # depth 0 → outside slab
+    assert surf.get_at((3, 3))[:3] == (0, 0, 0)
+
+
+def test_slab_bounds_are_half_open():
+    fg = np.zeros((4, 4), dtype=np.uint16)
+    fg[0, 0] = 800   # near_mm — inclusive
+    fg[1, 1] = 2500  # far_mm  — exclusive
+    fg[2, 2] = 799   # just below near — excluded
+    surf = _identity_surf(fg)
+    assert surf.get_at((0, 0))[:3] == _COLOR        # 800 in
+    assert surf.get_at((1, 1))[:3] == (0, 0, 0)     # 2500 out
+    assert surf.get_at((2, 2))[:3] == (0, 0, 0)     # 799 out
+
+
+def test_multiple_slabs_union():
+    fg = np.zeros((4, 4), dtype=np.uint16)
+    fg[0, 0] = 1500   # slab 0
+    fg[3, 3] = 3000   # slab 1
+    slabs = _SLAB + [{"near_mm": 2500, "far_mm": 4000, "slab_id": 1}]
+    surf = _identity_surf(fg, slabs=slabs)
+    assert surf.get_at((0, 0))[:3] == _COLOR
+    assert surf.get_at((3, 3))[:3] == _COLOR
+
+
+def test_roi_crop_and_scale_to_size():
+    fg = np.zeros((8, 8), dtype=np.uint16)
+    roi = {"x": 2, "y": 2, "w": 4, "h": 4}
+    surf = render_silhouette(fg, _SLAB, roi, _COLOR, 200, 120)
+    assert surf.get_size() == (200, 120)


### PR DESCRIPTION
## What
  The depth→silhouette mapping (crop ROI, mask by Depth Slab, paint, scale)
  was implemented byte-for-byte 3×:
  - `app.py::_silhouette_surf` (attract overlay)
  - `games/bodycaptcha.py::_foreground_surf`
  - `games/body_keepaway.py::_foreground_surf`

  A Depth-Slab or camera-ROI change had to land in all three in lockstep.
  
  ## Change
  One deep module: `silhouette.render_silhouette(fg, slabs_cfg, roi, color, w, h)`.
  3 call sites import + call it; duplicated defs deleted. Net −19 LOC.
  
  ## Tests
  New `test_silhouette.py` (first test for this logic): half-open slab bounds,
  multi-slab union, ROI crop + scale-to-size. Full suite: **119 passed**.