### PR TITLE
Name the Arc — extract the game lifecycle into a module

### DIFF
--- a/ShowControl/FundingCAPTCHA/app.py
+++ b/ShowControl/FundingCAPTCHA/app.py
@@ -24,7 +24,6 @@ import importlib.util
 import json
 import logging
 import queue
-import random
 import sys
 import threading
 import time
@@ -45,6 +44,7 @@ sys.path.insert(0, str(DIR.parent))         # OSCFabric
 sys.path.insert(0, str(DIR))                # body_grid, games
 
 from silhouette import build_cam_transform, apply_cam_transform, render_silhouette
+from arc import Arc, Game, ShuffleBag
 
 # ── Optional imports ──────────────────────────────────────────────────────────
 try:
@@ -337,29 +337,10 @@ class TestInputHandler:
         screen.blit(surf, (0, 0))
 
 
-# ── Game interface ────────────────────────────────────────────────────────────
-
-class Game:
-    """Base class for FundingCAPTCHA games.
-
-    update() args: foreground (uint16 H×W numpy array or None), dt (seconds)
-    update() returns: (intensity 0–1, event 'loss' | None)
-    """
-
-    def update(self, foreground: np.ndarray | None, dt: float) -> tuple[float, str | None]:
-        return 0.0, None
-
-    def draw(self, surf: pygame.Surface) -> None:
-        pass
-
-    def reset(self) -> None:
-        pass
-
-
-class _NoGame(Game):
-    def draw(self, surf: pygame.Surface) -> None:
-        surf.fill(DK_GREY)
-
+# ── Game loading ──────────────────────────────────────────────────────────────
+# The Game interface, _NoGame stand-in, ShuffleBag, and the Arc lifecycle now
+# live in arc.py — imported above. This module only knows how to find and load
+# Games from disk; selecting and running them is the Arc's job.
 
 def _load_games(settings: dict) -> list[Game]:
     games: list[Game] = []
@@ -378,20 +359,6 @@ def _load_games(settings: dict) -> list[Game]:
         except Exception as exc:
             log.warning("Could not load game %s: %s", name, exc)
     return games
-
-
-class _ShuffleBag:
-    def __init__(self, items: list) -> None:
-        self._items = list(items)
-        self._bag:  list = []
-
-    def next(self) -> Any | None:
-        if not self._items:
-            return None
-        if not self._bag:
-            self._bag = list(self._items)
-            random.shuffle(self._bag)
-        return self._bag.pop()
 
 
 # ── Screensaver interface ─────────────────────────────────────────────────────
@@ -534,15 +501,12 @@ def main() -> None:
     # Full-screen game area (no HUD column — ADR-0019)
     game_w = WW
 
-    # ── Games ─────────────────────────────────────────────────────────────────
-    games      = _load_games(settings)
-    game_bag   = _ShuffleBag(games)
-    no_game    = _NoGame()
-    cur_game   = no_game
+    # ── Arc ───────────────────────────────────────────────────────────────────
+    arc        = Arc(_load_games(settings))
 
     # ── Screensavers ──────────────────────────────────────────────────────────
     savers     = _load_screensavers(settings)
-    saver_bag  = _ShuffleBag(savers)
+    saver_bag  = ShuffleBag(savers)
     no_saver   = _NoSaver()
     cur_saver  = saver_bag.next() or no_saver
 
@@ -592,7 +556,6 @@ def main() -> None:
     cal_started        = False    # have we signalled the camera to collect yet?
     cal_done_seen      = False    # has the camera finished building the model?
     t_last_osc         = time.monotonic()
-    intensity          = 0.0
 
     _start_camera()
 
@@ -615,7 +578,6 @@ def main() -> None:
                     cal_elapsed        = 0.0
                     cal_started        = False
                     cal_done_seen      = False
-                    intensity          = 0.0
                     threading.Thread(target=_do_restart, daemon=True).start()
                 elif event.key == pygame.K_c and test_handler:
                     test_handler.clear()
@@ -629,7 +591,6 @@ def main() -> None:
             cal_elapsed        = 0.0
             cal_started        = False
             cal_done_seen      = False
-            intensity          = 0.0
             threading.Thread(target=_do_restart, daemon=True).start()
 
         # Test-input: update paint canvas and push as foreground frame
@@ -745,34 +706,31 @@ def main() -> None:
                 screen.blit(t_big, t_big.get_rect(center=(game_w // 2, WH // 2 - 40)))
 
                 if attract_elapsed >= attract_dwell:
-                    state         = AppState.GAME
+                    state           = AppState.GAME
                     attract_elapsed = 0.0
-                    cur_game      = game_bag.next() or no_game
-                    cur_game.reset()
-                    intensity     = 0.0
-                    log.info("Player detected — starting Arc (%s)", type(cur_game).__name__)
+                    game_name       = arc.start()
+                    log.info("Player detected — starting Arc (%s)", game_name)
                     broadcast({"state": "game"})
             else:
                 attract_elapsed = 0.0
 
         elif state == AppState.GAME:
-            intensity, event = cur_game.update(current_foreground, dt)
-            cur_game.draw(screen)
+            status = arc.update(current_foreground, dt)
+            arc.draw(screen)
 
-            if event in ("loss", "win"):
-                log.info("Arc ended (%s) — returning to screensaver", event)
-                if fabric and event == "loss":
+            if status.finished:
+                log.info("Arc ended — returning to screensaver")
+                if fabric and status.blewup:
                     fabric.send_event("blowup")
                 state         = AppState.SCREENSAVER
                 cur_saver     = saver_bag.next() or no_saver
                 saver_elapsed = 0.0
-                intensity     = 0.0
                 broadcast({"state": "screensaver"})
 
             now = time.monotonic()
             if now - t_last_osc >= 0.1 and fabric:
                 t_last_osc = now
-                fabric.report("intensity", float(intensity))
+                fabric.report("intensity", float(status.intensity))
 
         # Test-input overlay
         if test_handler:

--- a/ShowControl/FundingCAPTCHA/arc.py
+++ b/ShowControl/FundingCAPTCHA/arc.py
@@ -1,0 +1,129 @@
+"""The Arc — FundingCAPTCHA's central game lifecycle (ADR-0012).
+
+One Arc = one player's run: select a Game, play it through, end in a Blow-Up
+(loss) or a survival (win), then hand back to the Screensaver. The app loop
+drives the Arc through a single interface — `update(foreground, dt) → ArcStatus`
+— and never sees the Game's internal `_State` machine or the `'loss'/'win'`
+event strings; those are the Arc's private vocabulary.
+
+ADR-0012 names `AppStateMachine` as an internal module of the unified pygame
+process. The Arc is the slice of that module the diagram drew but the code kept
+inline in the loop. No new process — one process, one more real module.
+"""
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+
+import numpy as np
+import pygame
+
+# Matches app.DK_GREY — the blank-frame fill when no Game is loaded.
+_DK_GREY = (28, 28, 28)
+
+
+def blend_intensity(progress_5: float, elapsed: float, duration: float,
+                    w_difficulty: float, w_time: float) -> float:
+    """Blend difficulty and time-pressure into a 0–1 Intensity.
+
+    `progress_5` is a 1–5 difficulty/level measure; `elapsed`/`duration` are the
+    Game's own clock. Single source of truth for the Intensity formula shared by
+    every Game (BodyCaptcha, BodyKeepaway) — the value the Arc reports to the
+    TreeHouse over OSC.
+    """
+    return max(0.0, min(1.0,
+        w_difficulty * progress_5 / 5.0 +
+        w_time * elapsed / max(duration, 0.001)))
+
+
+@dataclass(frozen=True)
+class ArcStatus:
+    """What the app loop needs after one Arc tick.
+
+    intensity — 0–1 drive level, reported to the TreeHouse over OSC.
+    blewup    — the Blow-Up Signal fired this tick (loss). Send it once.
+    finished  — the Arc ended this tick (win or loss). Return to the Screensaver.
+    """
+    intensity: float
+    blewup: bool
+    finished: bool
+
+
+class Game:
+    """Interface every FundingCAPTCHA game satisfies.
+
+    update(foreground, dt) → (intensity 0–1, event 'loss' | 'win' | None)
+      foreground: uint16 H×W depth frame, or None.
+    The event strings live behind the Arc; the app loop reads ArcStatus instead.
+    """
+
+    def update(self, foreground: np.ndarray | None, dt: float) -> tuple[float, str | None]:
+        return 0.0, None
+
+    def draw(self, surf: pygame.Surface) -> None:
+        pass
+
+    def reset(self) -> None:
+        pass
+
+
+class _NoGame(Game):
+    """Stand-in when no Game loaded — keeps the Arc total even on a bare box."""
+
+    def draw(self, surf: pygame.Surface) -> None:
+        surf.fill(_DK_GREY)
+
+
+class ShuffleBag:
+    """Draw items in random order, refilling once the bag empties.
+
+    No item repeats until every other item has been drawn — kills the
+    clustering of plain `random.choice`. Used for both Games and Screensavers.
+    """
+
+    def __init__(self, items: list) -> None:
+        self._items = list(items)
+        self._bag:  list = []
+
+    def next(self):
+        if not self._items:
+            return None
+        if not self._bag:
+            self._bag = list(self._items)
+            random.shuffle(self._bag)
+        return self._bag.pop()
+
+
+class Arc:
+    """The central lifecycle: select a Game, run it, surface a Blow-Up.
+
+    The app loop calls `start()` when a player is detected, then `update()` once
+    per tick until ArcStatus.finished, reading `intensity` for OSC and `blewup`
+    to fire the Blow-Up Signal. Game selection, reset, and the loss/win → boolean
+    mapping all live here.
+    """
+
+    def __init__(self, games: list) -> None:
+        self._bag     = ShuffleBag(games)
+        self._no_game = _NoGame()
+        self._game: Game = self._no_game
+
+    def start(self) -> str:
+        """Begin a fresh Arc: select the next Game and reset it.
+
+        Returns the Game's class name (for logging/monitoring).
+        """
+        self._game = self._bag.next() or self._no_game
+        self._game.reset()
+        return type(self._game).__name__
+
+    def update(self, foreground: np.ndarray | None, dt: float) -> ArcStatus:
+        intensity, event = self._game.update(foreground, dt)
+        return ArcStatus(
+            intensity = intensity,
+            blewup    = (event == "loss"),
+            finished  = (event in ("loss", "win")),
+        )
+
+    def draw(self, surf: pygame.Surface) -> None:
+        self._game.draw(surf)

--- a/ShowControl/FundingCAPTCHA/games/body_keepaway.py
+++ b/ShowControl/FundingCAPTCHA/games/body_keepaway.py
@@ -20,6 +20,7 @@ from games.grid import (
 )
 from body_grid import BodyGridActivator, BodyGridConfig, SlabConfig, CellActivations
 from silhouette import render_silhouette
+from arc import blend_intensity
 
 _DIR    = Path(__file__).parent.parent
 _LEVELS = _DIR / "keepaway-body-levels.json"
@@ -331,10 +332,8 @@ class BodyKeepawayGame:
         self._elapsed += dt
         level_idx      = self._level_idx + 1  # 1-based
 
-        self._intensity = max(0.0, min(1.0,
-            self._w_diff * level_idx / 5.0 +
-            self._w_time * self._elapsed / max(self._survive_s, 0.001)
-        ))
+        self._intensity = blend_intensity(level_idx, self._elapsed, self._survive_s,
+                                          self._w_diff, self._w_time)
 
         for d in self._defenders:
             d.move(dt, runner_cells)

--- a/ShowControl/FundingCAPTCHA/games/bodycaptcha.py
+++ b/ShowControl/FundingCAPTCHA/games/bodycaptcha.py
@@ -21,6 +21,7 @@ from games.grid import (
 )
 from body_grid import BodyGridActivator, BodyGridConfig, SlabConfig, CellActivations
 from silhouette import render_silhouette
+from arc import blend_intensity
 
 _DIR    = Path(__file__).parent.parent
 _IMAGES = _DIR / "images"
@@ -278,10 +279,8 @@ class BodyCaptchaGame:
         difficulty     = self._level.get("difficulty", 1)
         timer_s        = self._timer_s
 
-        self._intensity = max(0.0, min(1.0,
-            self._w_diff * difficulty / 5.0 +
-            self._w_time * self._elapsed / max(timer_s, 0.001)
-        ))
+        self._intensity = blend_intensity(difficulty, self._elapsed, timer_s,
+                                          self._w_diff, self._w_time)
 
         if self._elapsed >= timer_s:
             self._begin_blowup()

--- a/ShowControl/FundingCAPTCHA/test_arc.py
+++ b/ShowControl/FundingCAPTCHA/test_arc.py
@@ -1,0 +1,117 @@
+"""Tests for the Arc — the central game lifecycle.
+
+The Arc's test surface is exactly what the report promised: drive a Game through
+the Arc frame by frame and assert the Blow-Up Signal fires once, win finishes
+without it, and an ongoing Arc stays live. No camera, no display.
+"""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")  # headless: no real display
+
+import numpy as np
+
+from arc import Arc, ArcStatus, ShuffleBag, blend_intensity
+
+
+class _ScriptedGame:
+    """A Game that returns a fixed sequence of (intensity, event) per update."""
+
+    def __init__(self, script: list[tuple[float, str | None]]) -> None:
+        self._script = list(script)
+        self.reset_calls = 0
+        self.drawn = False
+
+    def update(self, foreground, dt):
+        return self._script.pop(0)
+
+    def draw(self, surf):
+        self.drawn = True
+
+    def reset(self):
+        self.reset_calls += 1
+
+
+# ── ArcStatus mapping ───────────────────────────────────────────────────────
+
+def test_loss_sets_blewup_and_finished():
+    arc = Arc([_ScriptedGame([(0.7, "loss")])])
+    arc.start()
+    status = arc.update(None, 0.1)
+    assert status == ArcStatus(intensity=0.7, blewup=True, finished=True)
+
+
+def test_win_finishes_without_blewup():
+    arc = Arc([_ScriptedGame([(0.9, "win")])])
+    arc.start()
+    status = arc.update(None, 0.1)
+    assert status.finished is True
+    assert status.blewup is False
+    assert status.intensity == 0.9
+
+
+def test_ongoing_arc_is_not_finished():
+    arc = Arc([_ScriptedGame([(0.3, None)])])
+    arc.start()
+    status = arc.update(None, 0.1)
+    assert status.finished is False
+    assert status.blewup is False
+    assert status.intensity == 0.3
+
+
+def test_drive_frames_until_blowup_fires_once():
+    # Play three live frames, then the Game blows up. blewup fires on exactly
+    # the loss tick — the Blow-Up Signal is sent once, not every frame after.
+    game = _ScriptedGame([(0.1, None), (0.4, None), (0.8, None), (1.0, "loss")])
+    arc  = Arc([game])
+    arc.start()
+    blewups = [arc.update(None, 0.1).blewup for _ in range(4)]
+    assert blewups == [False, False, False, True]
+
+
+def test_start_selects_and_resets_a_game():
+    game = _ScriptedGame([(0.0, None)])
+    arc  = Arc([game])
+    name = arc.start()
+    assert name == "_ScriptedGame"
+    assert game.reset_calls == 1
+
+
+def test_start_falls_back_to_no_game_when_empty():
+    arc = Arc([])
+    name = arc.start()
+    assert name == "_NoGame"
+    # _NoGame just idles — never finishes, never blows up.
+    status = arc.update(None, 0.1)
+    assert status == ArcStatus(intensity=0.0, blewup=False, finished=False)
+
+
+# ── ShuffleBag ──────────────────────────────────────────────────────────────
+
+def test_shuffle_bag_draws_all_before_repeating():
+    bag   = ShuffleBag(["a", "b", "c"])
+    first = {bag.next() for _ in range(3)}
+    assert first == {"a", "b", "c"}          # whole set drawn, no repeat
+    assert bag.next() in {"a", "b", "c"}     # refills on the 4th draw
+
+
+def test_shuffle_bag_empty_returns_none():
+    assert ShuffleBag([]).next() is None
+
+
+# ── blend_intensity ─────────────────────────────────────────────────────────
+
+def test_blend_intensity_combines_weighted_terms():
+    # difficulty 5/5 * 0.4  +  half the timer * 0.6  =  0.4 + 0.3 = 0.7
+    assert blend_intensity(5, 5.0, 10.0, 0.4, 0.6) == 0.7
+
+
+def test_blend_intensity_clamps_to_unit_range():
+    assert blend_intensity(10, 100.0, 1.0, 0.4, 0.6) == 1.0
+    assert blend_intensity(0, 0.0, 10.0, 0.4, 0.6) == 0.0
+
+
+def test_blend_intensity_guards_zero_duration():
+    # No division-by-zero on a zero-length Game clock.
+    assert blend_intensity(0, 1.0, 0.0, 0.4, 0.6) == 1.0


### PR DESCRIPTION
## What
The **Arc** — FundingCAPTCHA's central concept (select a Game, play it, end in Blow-Up or survival, return to the Screensaver) — had no module. Its lifecycle was smeared across the app loop, two private `_State` enums, and a `(float, 'loss'|'win'|None)` string-return contract the loop decoded inline.

## Change
New `arc.py`, one interface:

    Arc.update(foreground, dt) → ArcStatus(intensity, blewup, finished)

- Game selection (`ShuffleBag`) + reset live behind `Arc.start()`
- `'loss'/'win'` map to booleans **inside** Arc — magic-string seam deleted from the loop
- `blewup` = Blow-Up Signal (sent once, on loss); `win` finishes silently
- `Game`, `_NoGame`, `ShuffleBag` move into `arc.py` (savers still reuse `ShuffleBag`)
- `blend_intensity()` collapses the byte-identical Intensity formula duplicated in both games into one tested function

## ADR
Aligns with **ADR-0012** — already names `AppStateMachine` an internal module of the unified process; this extracts the slice the diagram drew but the code kept inline. No new process.

## Tests
New `test_arc.py` (first test surface for the lifecycle): drive frames → Blow-Up fires once, win finishes without it, `ShuffleBag` draws all before repeating, `blend_intensity` clamps. **Full suite: 130 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)